### PR TITLE
Change:Ignore events if not applicable to the current state

### DIFF
--- a/lib/aasm/event.rb
+++ b/lib/aasm/event.rb
@@ -27,8 +27,8 @@ class AASM::SupportingClasses::Event
   
   def fire(obj, to_state=nil, *args)
     transitions = @transitions.select { |t| t.from == obj.aasm_current_state }
-    raise AASM::InvalidTransition, "Event '#{name}' cannot transition from '#{obj.aasm_current_state}'" if transitions.size == 0
-
+    #raise AASM::InvalidTransition, "Event '#{name}' cannot transition from '#{obj.aasm_current_state}'" if transitions.size == 0
+    return false if transitions.size == 0
     next_state = nil
     transitions.each do |transition|
       next if to_state and !Array(transition.to).include?(to_state)


### PR DESCRIPTION
...just return false instead of throwing exception. Changed event.rb to not throw exception when there is not transition defined for the current state for the event.
