### PR TITLE
Keep options in subclasses

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -7,13 +7,13 @@ module AASM
 
       if options.key?(:whiny_transitions)
         sm.config.whiny_transitions = options[:whiny_transitions]
-      else
+      elsif sm.config.whiny_transitions.nil?
         sm.config.whiny_transitions = true # this is the default, so let's cry
       end
 
       if options.key?(:skip_validation_on_save)
         sm.config.skip_validation_on_save = options[:skip_validation_on_save]
-      else
+      elsif sm.config.skip_validation_on_save.nil?
         sm.config.skip_validation_on_save = false # this is the default, so don't store any new state if the model is invalid
       end
     end

--- a/spec/models/sub_classing.rb
+++ b/spec/models/sub_classing.rb
@@ -1,0 +1,3 @@
+class SubClassing < Silencer
+  
+end

--- a/spec/unit/state_transition_spec.rb
+++ b/spec/unit/state_transition_spec.rb
@@ -8,12 +8,18 @@ describe 'transitions' do
     process.should be_sleeping
   end
 
-  it 'should not raise an exception when whiny' do
+  it 'should not raise an exception when not whiny' do
     silencer = Silencer.new
     silencer.smile!.should be_false
     silencer.should be_silent
   end
 
+  it 'should not raise an exception when superclass not whiny' do
+    sub = SubClassing.new
+    sub.smile!.should be_false
+    sub.should be_silent
+  end
+  
 end
 
 describe AASM::SupportingClasses::StateTransition do


### PR DESCRIPTION
Currently, when a class with an AASM declaration is subclassed and a transition is performed on the sublcass, the options are reset to the default values. So even if, e.g., :whiny_transitions is set to false, on the subclass it will be reset to true. This is due to the implementation of AASM::Base and the storage of these instances in a class-side instance variable (AASM::ClassMethods.aasm).

This commit sets options only if they do not exist yet to fix this issue.
