### PR TITLE
Adding license information

### DIFF
--- a/aasm.gemspec
+++ b/aasm.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{State machine mixin for Ruby objects}
   s.description = %q{AASM is a continuation of the acts as state machine rails plugin, built for plain Ruby objects.}
   s.date        = Time.now
+  s.licenses    = ["MIT"]
 
   s.add_dependency             'activerecord'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Hi,

I use an automatic tool to track the licenses of the libraries I use and I noticed AASM doesn't specify the license in the gemspec.  I'd really like to be able to track your gem using this tool.  I'm submitting a pull request to change this.

Thanks,
Andrew.
