### PR TITLE
Use Ruby's initialize_copy for clone/dup

### DIFF
--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -3,11 +3,11 @@ module AASM
     def self.[](clazz)
       (@machines ||= {})[clazz.to_s]
     end
-  
+
     def self.[]=(clazz, machine)
       (@machines ||= {})[clazz.to_s] = machine
     end
-  
+
     attr_accessor :states, :events, :initial_state, :config
     attr_reader :name
 
@@ -19,11 +19,10 @@ module AASM
       @config = OpenStruct.new
     end
 
-    def clone
-      klone = super
-      klone.states = states.clone
-      klone.events = events.clone
-      klone
+    def initialize_copy(orig)
+      super
+      @states = @states.dup
+      @events = @events.dup
     end
 
     def create_state(name, options)


### PR DESCRIPTION
Ruby provides a method for implementing deep-copy on
objects called initialize_copy. This gets called after
a clone or dup, and is the more idiomatic way to handle
the sort of thing being done in the previously-defined
clone method.
