### PR TITLE
AASM defines constants for each state name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+ * added autocreation of constants for each state ([@jherdman](https://github.com/jherdman))
+
 ## 3.0.16
 
  * added autocreation of state scopes for Mongoid (thanks to [@jonnyshields](https://github.com/johnnyshields))

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -32,6 +32,10 @@ module AASM
       @clazz.send(:define_method, "#{name.to_s}?") do
         aasm_current_state == name
       end
+
+      unless @clazz.const_defined?("STATE_#{name.to_s.upcase}")
+        @clazz.const_set("STATE_#{name.to_s.upcase}", name)
+      end
     end
 
     # define an event

--- a/spec/unit/simple_example_spec.rb
+++ b/spec/unit/simple_example_spec.rb
@@ -50,4 +50,10 @@ describe 'state machine' do
     lambda {payment.fill_out}.should raise_error(AASM::InvalidTransition)
     lambda {payment.fill_out!}.should raise_error(AASM::InvalidTransition)
   end
+
+  it 'defines constants for each state name' do
+    Payment::STATE_INITIALISED.should eq(:initialised)
+    Payment::STATE_FILLED_OUT.should eq(:filled_out)
+    Payment::STATE_AUTHORISED.should eq(:authorised)
+  end
 end


### PR DESCRIPTION
So, I found I was hard coding state names in situations such as tests, or custom scopes. Hard coding such things is a bad thing, so I wrote this pull request to auto-define constants for each defined state.

Example:

``` ruby
class Foo
  include AASM

  aasm do
    state :initialized
    state :calculated
    state :finalized
  end
end

> Foo::STATE_INITIALIZED
#=> :initialized
> Foo::STATE_CALCULATED
#=> :calculated
```
