### PR TITLE
Fix doc for inspection methods - they should use .aasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,16 +313,16 @@ Given the `Job` class from above:
 ```ruby
 job = Job.new
 
-job.states
+job.aasm.states
 => [:sleeping, :running, :cleaning]
 
-job.states(:permissible => true)
+job.aasm.states(:permissible => true)
 => [:running]
 job.run
-job.states(:permissible => true)
+job.aasm.states(:permissible => true)
 => [:cleaning, :sleeping]
 
-job.events
+job.aasm.events
 => [:run, :clean, :sleep]
 ```
 


### PR DESCRIPTION
E.g. job.events should be job.aasm.events
