### PR TITLE
Ensure that may_whatever? always returns either true or false

### DIFF
--- a/lib/aasm/event.rb
+++ b/lib/aasm/event.rb
@@ -64,16 +64,16 @@ module AASM
       self
     end
 
-    # Execute if test? == false, otherwise return true/false depending on whether it would fire
+    # Execute if test == false, otherwise return true/false depending on whether it would fire
     def _fire(obj, test, to_state=nil, *args)
+      result = test ? false : nil
       if @transitions.map(&:from).any?
         transitions = @transitions.select { |t| t.from == obj.aasm_current_state }
-        return nil if transitions.size == 0
+        return result if transitions.size == 0
       else
         transitions = @transitions
       end
 
-      result = test ? false : nil
       transitions.each do |transition|
         next if to_state and !Array(transition.to).include?(to_state)
         if transition.perform(obj, *args)


### PR DESCRIPTION
Instead of nil if there are no possible transitions and false if one exists but it is not allowed.
