### PR TITLE
Allow overwriting of events, can be very useful with inheritance

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -48,9 +48,7 @@ module AASM
     def event(name, options={}, &block)
       # @clazz.aasm_event(name, options, &block)
 
-      unless @state_machine.events.has_key?(name)
-        @state_machine.events[name] = AASM::Event.new(name, options, &block)
-      end
+      @state_machine.events[name] = AASM::Event.new(name, options, &block)
 
       # an addition over standard aasm so that, before firing an event, you can ask
       # may_event? and get back a boolean that tells you whether the guard method


### PR DESCRIPTION
Hi,

First, thanks for this gem, it helps a lot, that's some very good stuff you made here :)

I had a problem with inheritance, I wanted an event in a child class to have different transitions than it's parent version.

Here's an example

``` ruby
class Parent
  include AASM

  aasm do
    state :foo
    state :bar
    state :baz

    event :some_event do
      transitions :from => [:bar]
    end

  end

end

class Child < Parent
  aasm do
    state :other

    event :some_event do
      transitions :from => [:bar, :other]
    end
  end
end
```

Without this patch `some_event` won't be able to get called from `:other`

What do you think ?
