### PR TITLE
Allow a block to be called when running a transition

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -57,12 +57,12 @@ module AASM
         aasm.may_fire_event?(name, *args)
       end
 
-      @clazz.send(:define_method, "#{name.to_s}!") do |*args|
-        aasm_fire_event(name, {:persist => true}, *args)
+      @clazz.send(:define_method, "#{name.to_s}!") do |*args, &block|
+        aasm_fire_event(name, {:persist => true}, *args, &block)
       end
 
-      @clazz.send(:define_method, "#{name.to_s}") do |*args|
-        aasm_fire_event(name, {:persist => false}, *args)
+      @clazz.send(:define_method, "#{name.to_s}") do |*args, &block|
+        aasm_fire_event(name, {:persist => false}, *args, &block)
       end
     end
 

--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -131,7 +131,7 @@ module AASM
           aasm.enter_initial_state if send(self.class.aasm_column).blank?
         end
 
-        def aasm_fire_event(name, options, *args)
+        def aasm_fire_event(name, options, *args, &block)
           self.class.transaction(:requires_new => true) do
             super
           end

--- a/spec/unit/transition_spec.rb
+++ b/spec/unit/transition_spec.rb
@@ -26,6 +26,29 @@ describe 'transitions' do
     silencer.should be_smiling
   end
 
+  it 'should call the block when success' do
+    silencer = Silencer.new
+    success = false
+    lambda {
+      silencer.smile_any! do
+        success = true
+      end
+    }.should change { success }.to(true)
+  end
+
+  it 'should not call the block when failure' do
+    silencer = Silencer.new
+    success = false
+    lambda {
+      silencer.smile! do
+        success = true
+      end
+    }.should_not change { success }.to(true)
+  end
+
+end
+
+describe 'blocks' do
 end
 
 describe AASM::Transition do


### PR DESCRIPTION
Hi,

This is based on the former `run_transition` method of the old acts_as_state_machine gem from @rubyist

Sometimes, you want to do an action only if the transition succeeds, but you also want to call the failed callbacks when it does not.

I did not find any way to do this natively (feel free to point out some existing ways if there are), so I implemented this little feature.

``` ruby
object.transition! do
  some_code
end
```

`some_code` will be called only if the transition succeeds, before launching the after_enter callbacks.
