### PR TITLE
Add an ActiveRecord validation

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -36,6 +36,8 @@ module AASM
         else
           base.before_validation_on_create(:aasm_ensure_initial_state)
         end
+
+        base.validate :aasm_validate_states
       end
 
       module ClassMethods
@@ -142,6 +144,14 @@ module AASM
           end
 
           success
+        end
+
+        def aasm_validate_states
+          unless AASM::StateMachine[self.class].config.skip_validation_on_save
+            if aasm.current_state && !aasm.states.include?(aasm.current_state)
+              self.errors.add(AASM::StateMachine[self.class].config.column , "is invalid")
+            end
+          end
         end
       end # InstanceMethods
 

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -221,3 +221,26 @@ describe 'transitions with persistence' do
     end
   end
 end
+
+describe "invalid states with persistence" do
+
+  it "should not store states" do
+    validator = Validator.create(:name => 'name')
+    validator.status = 'invalid_state'
+    validator.save.should be_false
+    lambda {validator.save!}.should raise_error(ActiveRecord::RecordInvalid)
+
+    validator.reload
+    validator.should be_sleeping
+  end
+
+  it "should store invalid states if configured" do
+    persistor = InvalidPersistor.create(:name => 'name')
+    persistor.status = 'invalid_state'
+    persistor.save.should be_true
+
+    persistor.reload
+    persistor.status.should == 'invalid_state'
+  end
+
+end


### PR DESCRIPTION
Add a validation to prevent invalid states to persist. So,

``` ruby
class Example < ActiveRecord::Base
  include AASM
  aasm do
    state :one
  end
end
record = Example.create
record.aasm_state = 'an_invalid_state'
record.save # => false
```

Let me know what you think!
