### PR TITLE
Fix after_commit callback doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ class Job < ActiveRecord::Base
 
   aasm do
     state :sleeping, :initial => true
-    state :running
+    state :running, :after_commit => :notify_about_running_job
 
-    event :run, :after_commit => :notify_about_running_job do
+    event :run do
       transitions :from => :sleeping, :to => :running
     end
   end


### PR DESCRIPTION
The callback should be assigned on the state as described in the spec https://github.com/aasm/aasm/blob/master/spec/models/validator.rb#L7
