### PR TITLE
Updated readme for Mongoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ to include Mongoid::Document before you include AASM.
 class Job
   include Mongoid::Document
   include AASM
+  field :aasm_state
   aasm do
     ...
   end


### PR DESCRIPTION
Added to `README` that `aasm_state` field must be included when using Mongoid.
