### PR TITLE
Updated README.md to refect actual code necessary to get states

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,13 +431,13 @@ Given the `Job` class from above:
 ```ruby
 job = Job.new
 
-job.aasm.states
+job.aasm.states.map { | state | state.name }
 => [:sleeping, :running, :cleaning]
 
-job.aasm.states(:permissible => true)
+job.aasm.states(:permissible => true).map { | state | state.name }
 => [:running]
 job.run
-job.aasm.states(:permissible => true)
+job.aasm.states(:permissible => true).map { | state | state.name }
 => [:cleaning, :sleeping]
 
 job.aasm.events


### PR DESCRIPTION
Code listing for Inspection did not reflect the code necessary to produce the output that was indicated.

job.aasm.states produces an array of AASM::State objects, which need mapping to produce the symbols necessary.
