### PR TITLE
use class method instead of instance method in scope example

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ class Job < ActiveRecord::Base
     state :cleaning
   end
 
-  def sleeping
+  def self.sleeping
     "This method name is in already use"
   end
 end


### PR DESCRIPTION
This change fixes a slight inaccuracy in the readme. The scope example in the readme references the instance method `sleeping` which is "already in use", but this is only true of the class method of the same name. 
