### PR TITLE
remove ivar name from AASM::StateMachine.initialize method

### DIFF
--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -5,7 +5,7 @@ module AASM
 
     # do not overwrite existing state machines, which could have been created by
     # inheritance, see class method inherited
-    AASM::StateMachine[base] ||= AASM::StateMachine.new('')
+    AASM::StateMachine[base] ||= AASM::StateMachine.new
 
     AASM::Persistence.load_persistence(base)
     super

--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -13,9 +13,7 @@ module AASM
     attr_accessor :states, :events, :initial_state, :config
     attr_reader :name
 
-    # QUESTION: what's the name for? [alto, 2012-11-28]
-    def initialize(name)
-      @name = name
+    def initialize
       @initial_state = nil
       @states = []
       @events = {}


### PR DESCRIPTION
I've take a look into [this line](https://github.com/aasm/aasm/blob/master/lib/aasm/state_machine.rb#L16), and I think instance variable "name" seems not to be used anywhere. Is it ok to remove this ivar?
