### PR TITLE
replace `clazz` to `klass` so to uniformize the variable name

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -1,9 +1,9 @@
 module AASM
   class Base
 
-    def initialize(clazz, options={}, &block)
-      @clazz = clazz
-      @state_machine = AASM::StateMachine[@clazz]
+    def initialize(klass, options={}, &block)
+      @klass = klass
+      @state_machine = AASM::StateMachine[@klass]
       @state_machine.config.column = options[:column].to_sym if options[:column]
       @options = options
 
@@ -30,15 +30,15 @@ module AASM
 
     # define a state
     def state(name, options={})
-      @state_machine.add_state(name, @clazz, options)
+      @state_machine.add_state(name, @klass, options)
       @state_machine.initial_state = name if options[:initial] || !@state_machine.initial_state
 
-      @clazz.send(:define_method, "#{name.to_s}?") do
+      @klass.send(:define_method, "#{name.to_s}?") do
         aasm.current_state == name
       end
 
-      unless @clazz.const_defined?("STATE_#{name.to_s.upcase}")
-        @clazz.const_set("STATE_#{name.to_s.upcase}", name)
+      unless @klass.const_defined?("STATE_#{name.to_s.upcase}")
+        @klass.const_set("STATE_#{name.to_s.upcase}", name)
       end
     end
 
@@ -49,15 +49,15 @@ module AASM
       # an addition over standard aasm so that, before firing an event, you can ask
       # may_event? and get back a boolean that tells you whether the guard method
       # on the transition will let this happen.
-      @clazz.send(:define_method, "may_#{name.to_s}?") do |*args|
+      @klass.send(:define_method, "may_#{name.to_s}?") do |*args|
         aasm.may_fire_event?(name, *args)
       end
 
-      @clazz.send(:define_method, "#{name.to_s}!") do |*args, &block|
+      @klass.send(:define_method, "#{name.to_s}!") do |*args, &block|
         aasm_fire_event(name, {:persist => true}, *args, &block)
       end
 
-      @clazz.send(:define_method, "#{name.to_s}") do |*args, &block|
+      @klass.send(:define_method, "#{name.to_s}") do |*args, &block|
         aasm_fire_event(name, {:persist => false}, *args, &block)
       end
     end

--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -87,26 +87,26 @@ module AASM
     # make sure to create a (named) scope for each state
     def state_with_scope(name, *args)
       state_without_scope(name, *args)
-      if AASM::StateMachine[@clazz].config.create_scopes && !@clazz.respond_to?(name)
-        if @clazz.ancestors.map {|klass| klass.to_s}.include?("ActiveRecord::Base")
+      if AASM::StateMachine[@klass].config.create_scopes && !@klass.respond_to?(name)
+        if @klass.ancestors.map {|klass| klass.to_s}.include?("ActiveRecord::Base")
 
-          conditions = {"#{@clazz.table_name}.#{@clazz.aasm_column}" => name.to_s}
+          conditions = {"#{@klass.table_name}.#{@klass.aasm_column}" => name.to_s}
           if ActiveRecord::VERSION::MAJOR >= 4
-            @clazz.class_eval do
+            @klass.class_eval do
               scope name, lambda { where(conditions) }
             end
           elsif ActiveRecord::VERSION::MAJOR >= 3
-            @clazz.class_eval do
+            @klass.class_eval do
               scope name, where(conditions)
             end
           else
-            @clazz.class_eval do
+            @klass.class_eval do
               named_scope name, :conditions => conditions
             end
           end
-        elsif @clazz.ancestors.map {|klass| klass.to_s}.include?("Mongoid::Document")
-          scope_options = lambda { @clazz.send(:where, {@clazz.aasm_column.to_sym => name.to_s}) }
-          @clazz.send(:scope, name, scope_options)
+        elsif @klass.ancestors.map {|klass| klass.to_s}.include?("Mongoid::Document")
+          scope_options = lambda { @klass.send(:where, {@klass.aasm_column.to_sym => name.to_s}) }
+          @klass.send(:scope, name, scope_options)
         end
       end
     end

--- a/lib/aasm/state.rb
+++ b/lib/aasm/state.rb
@@ -2,9 +2,9 @@ module AASM
   class State
     attr_reader :name, :options
 
-    def initialize(name, clazz, options={})
+    def initialize(name, klass, options={})
       @name = name
-      @clazz = clazz
+      @klass = klass
       update(options)
     end
 
@@ -48,7 +48,7 @@ module AASM
     end
 
     def localized_name
-      AASM::Localizer.new.human_state_name(@clazz, self)
+      AASM::Localizer.new.human_state_name(@klass, self)
     end
     alias human_name localized_name
 

--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -2,12 +2,12 @@ module AASM
   class StateMachine
 
     # the following two methods provide the storage of all state machines
-    def self.[](clazz)
-      (@machines ||= {})[clazz.to_s]
+    def self.[](klass)
+      (@machines ||= {})[klass.to_s]
     end
 
-    def self.[]=(clazz, machine)
-      (@machines ||= {})[clazz.to_s] = machine
+    def self.[]=(klass, machine)
+      (@machines ||= {})[klass.to_s] = machine
     end
 
     attr_accessor :states, :events, :initial_state, :config
@@ -27,8 +27,8 @@ module AASM
       @events = @events.dup
     end
 
-    def add_state(name, clazz, options)
-      @states << AASM::State.new(name, clazz, options) unless @states.include?(name)
+    def add_state(name, klass, options)
+      @states << AASM::State.new(name, klass, options) unless @states.include?(name)
     end
 
   end # StateMachine

--- a/spec/unit/memory_leak_spec.rb
+++ b/spec/unit/memory_leak_spec.rb
@@ -2,8 +2,8 @@
 
 # describe "state machines" do
 
-#   def number_of_objects(clazz)
-#     ObjectSpace.each_object(clazz) {}
+#   def number_of_objects(klass)
+#     ObjectSpace.each_object(klass) {}
 #   end
 
 #   def machines


### PR DESCRIPTION
This pull request might be about coding style.
I looked into entire source and found that there are two variable names which are `clazz` and `klass` are used  to express the class.
Since ruby prefers `klass` as the variable name, I think it makes code more simple if we replace the `clazz` to `klass` and uniformizing it.
Is this a good idea?
