### PR TITLE
move setting initial_state codes to StateMachine class

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -31,7 +31,6 @@ module AASM
     # define a state
     def state(name, options={})
       @state_machine.add_state(name, @klass, options)
-      @state_machine.initial_state = name if options[:initial] || !@state_machine.initial_state
 
       @klass.send(:define_method, "#{name.to_s}?") do
         aasm.current_state == name

--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -28,7 +28,14 @@ module AASM
     end
 
     def add_state(name, klass, options)
+      set_initial_state(name, options)
       @states << AASM::State.new(name, klass, options) unless @states.include?(name)
+    end
+
+    private
+
+    def set_initial_state(name, options)
+      @initial_state = name if options[:initial] || !initial_state
     end
 
   end # StateMachine


### PR DESCRIPTION
I think setting @state_machine's initial_state codes in AASM::Base class belongs to StateMachine class.
It's better to have those kind of codes not in the class using the instance variable but in the instance variable's class itself. 
