### PR TITLE
remove unnecessary attr_reader in StateMachine class

### DIFF
--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -11,7 +11,6 @@ module AASM
     end
 
     attr_accessor :states, :events, :initial_state, :config
-    attr_reader :name
 
     def initialize
       @initial_state = nil


### PR DESCRIPTION
This PR relates to the issue https://github.com/aasm/aasm/pull/129.
I forgot to remove `attr_reader` for ivar `name`.
