### PR TITLE
Remove target state from event methods arguments

### DIFF
--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -154,7 +154,7 @@ private
       # new event before callback
       event.fire_callbacks(:before, self)
 
-      if new_state_name = event.fire(self, *args)
+      if new_state_name = event.fire(self, options[:to_state], *args)
         fired(event, old_state, new_state_name, options, &block)
       else
         failed(event_name, old_state)


### PR DESCRIPTION
There is no visible use-cases for implicit target state in event method arguments.

At least it should be done another, more implicit, way.

`obj.run!(:my_precious_argument) instead of obj.run!(:active, :my_precious_argument)`
