### PR TITLE
Use lambda when defining Rails 3 scopes

### DIFF
--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -91,13 +91,9 @@ module AASM
         if @klass.ancestors.map {|klass| klass.to_s}.include?("ActiveRecord::Base")
 
           conditions = {"#{@klass.table_name}.#{@klass.aasm_column}" => name.to_s}
-          if ActiveRecord::VERSION::MAJOR >= 4
+          if ActiveRecord::VERSION::MAJOR >= 3
             @klass.class_eval do
               scope name, lambda { where(conditions) }
-            end
-          elsif ActiveRecord::VERSION::MAJOR >= 3
-            @klass.class_eval do
-              scope name, where(conditions)
             end
           else
             @klass.class_eval do


### PR DESCRIPTION
The intention of this change is to ensure, that in Rails 3 the aasm scopes are defined at runtime (same as for Rails 4).

This fixes a problem with Rails migrations: When Rails runs migrations for creating a table for an aasm model, the aasm model could already be loaded (for example when using observers in application.rb). When loaded, it tries to access the database and fails because the table does not yet exists.
