### PR TITLE
added not_ methods to find objects not in the given state

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -36,13 +36,9 @@ module AASM
         aasm.current_state == name
       end
 
-
-
       unless @klass.const_defined?("STATE_#{name.to_s.upcase}")
         @klass.const_set("STATE_#{name.to_s.upcase}", name)
       end
-
-
     end
 
     # define an event
@@ -63,9 +59,6 @@ module AASM
       @klass.send(:define_method, "#{name.to_s}") do |*args, &block|
         aasm_fire_event(name, {:persist => false}, *args, &block)
       end
-
-
-
     end
 
     def states

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -36,8 +36,18 @@ module AASM
         aasm.current_state == name
       end
 
+      @klass.send(:define_method, "not_#{name.to_s}?") do
+        aasm.current_state != name
+      end
+
+
+
       unless @klass.const_defined?("STATE_#{name.to_s.upcase}")
         @klass.const_set("STATE_#{name.to_s.upcase}", name)
+      end
+
+      unless @klass.const_defined?("STATE_NOT#{name.to_s.upcase}")
+        @klass.const_set("STATE_NOT#{name.to_s.upcase}", name)
       end
     end
 
@@ -59,6 +69,18 @@ module AASM
       @klass.send(:define_method, "#{name.to_s}") do |*args, &block|
         aasm_fire_event(name, {:persist => false}, *args, &block)
       end
+
+      @klass.send(:define_method, "not_#{name.to_s}!") do |*args, &block|
+        aasm_fire_event(name, {:persist => true}, *args, &block)
+      end
+
+      @klass.send(:define_method, "not_#{name.to_s}") do |*args, &block|
+        aasm_fire_event(name, {:persist => false}, *args, &block)
+      end
+
+
+
+
     end
 
     def states

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -36,19 +36,13 @@ module AASM
         aasm.current_state == name
       end
 
-      @klass.send(:define_method, "not_#{name.to_s}?") do
-        aasm.current_state != name
-      end
-
 
 
       unless @klass.const_defined?("STATE_#{name.to_s.upcase}")
         @klass.const_set("STATE_#{name.to_s.upcase}", name)
       end
 
-      unless @klass.const_defined?("STATE_NOT#{name.to_s.upcase}")
-        @klass.const_set("STATE_NOT#{name.to_s.upcase}", name)
-      end
+
     end
 
     # define an event
@@ -69,15 +63,6 @@ module AASM
       @klass.send(:define_method, "#{name.to_s}") do |*args, &block|
         aasm_fire_event(name, {:persist => false}, *args, &block)
       end
-
-      @klass.send(:define_method, "not_#{name.to_s}!") do |*args, &block|
-        aasm_fire_event(name, {:persist => true}, *args, &block)
-      end
-
-      @klass.send(:define_method, "not_#{name.to_s}") do |*args, &block|
-        aasm_fire_event(name, {:persist => false}, *args, &block)
-      end
-
 
 
 

--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -52,6 +52,12 @@ module AASM
           end
         end
 
+        def find_not_in_state(number, state, *args)
+          with_not_state_scope state do
+            find(number, *args)
+          end
+        end
+
         def count_in_state(state, *args)
           with_state_scope state do
             count(*args)
@@ -70,6 +76,14 @@ module AASM
             yield if block_given?
           end
         end
+
+        #finder method for records where state is NOT the given state
+        def with_not_state_scope(state)
+          with_scope :find => {:conditions => ["#{table_name}.#{aasm_column} != ?", state.to_s]} do
+            yield if block_given?
+          end
+        end
+
       end
 
       module InstanceMethods

--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -83,7 +83,6 @@ module AASM
             yield if block_given?
           end
         end
-
       end
 
       module InstanceMethods

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -105,11 +105,6 @@ describe "named scopes with the new DSL" do
 
 end
 
-
-
-
-
-
 describe 'initial states' do
 
   it 'should support conditions' do

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -83,6 +83,13 @@ describe "named scopes with the new DSL" do
       expect(SimpleNewDsl).to respond_to(:unknown_scope)
       expect(SimpleNewDsl.unknown_scope.is_a?(ActiveRecord::Relation)).to be_true
     end
+
+    it "should add a not_ scope" do
+      expect(SimpleNewDsl).to respond_to(:not_unknown_scope)
+      expect(SimpleNewDsl.not_unknown_scope.is_a?(ActiveRecord::Relation)).to be_true
+    end
+
+
   end
 
   context "Already respond_to? the scope name" do
@@ -97,6 +104,11 @@ describe "named scopes with the new DSL" do
   end
 
 end
+
+
+
+
+
 
 describe 'initial states' do
 


### PR DESCRIPTION
aasm has built-in methods to find objects in the specified state; for example, for state 'foo' there is SomeModel.foo  will return a set of records with that state.

I've added similar methods prefixed with not_  , to find objects that are in any state other than the one specified.  For example,  SomeModel.not_foo would return a set of records with state 'bar' or 'woot' but not 'foo'.  

