### PR TITLE
Fix stack level too deep error due to namespacing

### DIFF
--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -155,16 +155,16 @@ private
       event.fire_callbacks(:before, self)
 
       if new_state_name = event.fire(self, *args)
-        fired(event, old_state, new_state_name, options, &block)
+        aasm_fired(event, old_state, new_state_name, options, &block)
       else
-        failed(event_name, old_state)
+        aasm_failed(event_name, old_state)
       end
     rescue StandardError => e
       event.fire_callbacks(:error, self, e) || raise(e)
     end
   end
 
-  def fired(event, old_state, new_state_name, options)
+  def aasm_fired(event, old_state, new_state_name, options)
     persist = options[:persist]
 
     new_state = aasm.state_object_for_name(new_state_name)
@@ -200,7 +200,7 @@ private
     persist_successful
   end
 
-  def failed(event_name, old_state)
+  def aasm_failed(event_name, old_state)
     if self.respond_to?(:aasm_event_failed)
       self.aasm_event_failed(event_name, old_state.name)
     end

--- a/spec/unit/event_naming_spec.rb
+++ b/spec/unit/event_naming_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+class SimpleStateMachine
+  include AASM
+
+  aasm do
+    state :init, :initial => true
+    state :failed
+
+    event :failed do
+      transitions :from => :init, :to => :failed
+    end
+  end
+end
+
+describe "event naming" do
+  let(:state_machine) { SimpleStateMachine.new }
+
+  it "allows an event of failed without blowing the stack" do
+    state_machine.failed
+
+    expect { state_machine.failed }.to raise_error(AASM::InvalidTransition)
+  end
+end


### PR DESCRIPTION
If you have a state machine with a "failed" event and you transition it
and it fails to transition, AASM will call the "failed" method it
defines but will hit your transition instead and blow the stack.

All other methods in AASM are prefixed with AASM to avoid this, so this
patch does the same thing with the private methods `failed` and `fired`.

This bit me on an existing state machine I had when upgrading versions. I think its common enough to have a "failed" event that solution should be on the library and not the user.
