### PR TITLE
Update readme for required to_state argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Also, you can pass parameters to events:
 
 In this case the `set_process` would be called with `:defragmentation` argument.
 
+Note that when passing arguments to a state transition, the first argument must be the desired end state. In the above example, we wish to transition to `:running` state and run the callback with `:defragmentation` argument. You can also pass in `nil` as the desired end state, and AASM will try to transition to the first end state defined for that event.
+
 In case of an error during the event processing the error is rescued and passed to `:error`
 callback, which can handle it or re-raise it for further propagation.
 


### PR DESCRIPTION
The documentation doesn't explain well the fact that when passing arguments to a state transition, the first argument must be the desired end state (or nil). I added some documentation to clarify this.
