### PR TITLE
Add :after_commit callbacks to events.

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -56,11 +56,13 @@ module AASM
 
       @klass.send(:define_method, "#{name.to_s}!") do |*args, &block|
         aasm.current_event = "#{name.to_s}!".to_sym
+        aasm.events_fired |= [name.to_sym]
         aasm_fire_event(name, {:persist => true}, *args, &block)
       end
 
       @klass.send(:define_method, "#{name.to_s}") do |*args, &block|
         aasm.current_event = name.to_sym
+        aasm.events_fired |= [name.to_sym]
         aasm_fire_event(name, {:persist => false}, *args, &block)
       end
     end

--- a/lib/aasm/event.rb
+++ b/lib/aasm/event.rb
@@ -130,7 +130,7 @@ module AASM
       end
     end
 
-    [:after, :before, :error, :success].each do |callback_name|
+    [:after, :before, :error, :success, :after_commit].each do |callback_name|
       define_method callback_name do |*args, &block|
         options[callback_name] = Array(options[callback_name])
         options[callback_name] << block if block

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -1,10 +1,11 @@
 module AASM
   class InstanceBase
 
-    attr_accessor :from_state, :to_state, :current_event
+    attr_accessor :from_state, :to_state, :current_event, :events_fired
 
     def initialize(instance)
       @instance = instance
+      @events_fired = []
     end
 
     def current_state

--- a/spec/models/validator.rb
+++ b/spec/models/validator.rb
@@ -4,22 +4,33 @@ class Validator < ActiveRecord::Base
   include AASM
   aasm :column => :status do
     state :sleeping, :initial => true
+    state :awake
     state :running, :after_commit => :change_name!
     state :failed, :after_enter => :fail, :after_commit => :change_name!
     event :run do
       transitions :to => :running, :from => :sleeping
     end
     event :sleep do
-      transitions :to => :sleeping, :from => :running
+      after_commit { append_name!(" slept") }
+      transitions :to => :sleeping, :from => [:running, :awake]
+    end
+    event :wake do
+      after_commit { append_name!(" awoke") }
+      transitions :to => :awake, :from => :sleeping
     end
     event :fail do
-      transitions :to => :failed, :from => [:sleeping, :running]
+      transitions :to => :failed, :from => [:sleeping, :running, :awake]
     end
   end
   validates_presence_of :name
 
   def change_name!
     self.name = "name changed"
+    save!
+  end
+
+  def append_name!(suffix)
+    self.name += suffix
     save!
   end
 


### PR DESCRIPTION
Event-specific :after_commit callbacks are called in the order that the events
were called.  They are called even when the record is manually persisted.  For
the sake of consistency, the same is now true of the state :after_commit
callback.  As in that case, this feature is specific to active record.

This is really useful when you a) have implicit state transitions; b) have
state-specific validations and  c) have event hooks that you only want to fire
once the transition is committed: for example because they can't be rolled back
(like notifications via a third party).

Imagine if you have something like the following:

``` rb
class Invoice
  aasm do
    state :due
    state :paid, after_commit: :notify_of_payment!

    event :pay do
      transitions from: :due, to: :paid
    end
  end

  with_options if: :paid? do
    validates_presence_of :transaction_id
  end

  def payment_number= n
    write_attribute :payment_number, n
    pay if payment_number_changed?
  end
end
```

You want `notify_of_payment!` to happen on the `pay` transition but only if the
invoice could actually be saved.  When there's state-specific validation it gets
tricky because you want to actually change state _before_ validation so you get
the state-specific validatino, but you want the hook to fire _after_ validation
(indeed after a succesful persistence).
