### PR TITLE
Fix example Instance-level inspection

### DIFF
--- a/README_FROM_VERSION_3_TO_4.md
+++ b/README_FROM_VERSION_3_TO_4.md
@@ -139,7 +139,7 @@ to
 ```ruby
 job = Job.new
 
-job.aasm.events(:permitted => true)
+job.aasm.events(:permitted => true).map(&:name)
 # => [:run]
 ```
 


### PR DESCRIPTION
The example for retrieving only permitted events returns an Array of Aasm Objects but not an Array of event names as symbols. This is fixed.
