### PR TITLE
Remove redundant to_s calls

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -56,12 +56,12 @@ module AASM
     def state(name, options={})
       @state_machine.add_state(name, @klass, options)
 
-      @klass.send(:define_method, "#{name.to_s}?") do
+      @klass.send(:define_method, "#{name}?") do
         aasm.current_state == name
       end
 
-      unless @klass.const_defined?("STATE_#{name.to_s.upcase}")
-        @klass.const_set("STATE_#{name.to_s.upcase}", name)
+      unless @klass.const_defined?("STATE_#{name.upcase}")
+        @klass.const_set("STATE_#{name.upcase}", name)
       end
     end
 
@@ -72,16 +72,16 @@ module AASM
       # an addition over standard aasm so that, before firing an event, you can ask
       # may_event? and get back a boolean that tells you whether the guard method
       # on the transition will let this happen.
-      @klass.send(:define_method, "may_#{name.to_s}?") do |*args|
+      @klass.send(:define_method, "may_#{name}?") do |*args|
         aasm.may_fire_event?(name, *args)
       end
 
-      @klass.send(:define_method, "#{name.to_s}!") do |*args, &block|
-        aasm.current_event = "#{name.to_s}!".to_sym
+      @klass.send(:define_method, "#{name}!") do |*args, &block|
+        aasm.current_event = "#{name}!".to_sym
         aasm_fire_event(name, {:persist => true}, *args, &block)
       end
 
-      @klass.send(:define_method, "#{name.to_s}") do |*args, &block|
+      @klass.send(:define_method, "#{name}") do |*args, &block|
         aasm.current_event = name.to_sym
         aasm_fire_event(name, {:persist => false}, *args, &block)
       end


### PR DESCRIPTION
Since you're using string interpolation, you're putting an unnecessary call to `to_s` in your strings
