### PR TITLE
Remove unused variable "value"

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -142,9 +142,9 @@ module AASM
 
         def aasm_raw_attribute_value(state)
           if aasm_enum
-            value = self.class.send(aasm_enum)[state]
+            self.class.send(aasm_enum)[state]
           else
-            value = state.to_s
+            state.to_s
           end
         end
 


### PR DESCRIPTION
Unused "value" variable storing the result of this method, you can simply pass your strings as the result without needing to store them onto a separate variable
