### PR TITLE
change method to check attribute_name

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -166,7 +166,7 @@ module AASM
         def aasm_ensure_initial_state
           # checking via respond_to? does not work in Rails <= 3
           # if respond_to?(self.class.aasm.attribute_name) && send(self.class.aasm.attribute_name).blank? # Rails 4
-          if attributes.key?(self.class.aasm.attribute_name.to_s) && send(self.class.aasm.attribute_name).blank?
+          if attribute_names.include?(self.class.aasm.attribute_name.to_s) && send(self.class.aasm.attribute_name).blank?
             aasm.enter_initial_state
           end
         end


### PR DESCRIPTION
Some popular gems like 'globalize' had rewrote method 'attributes': https://github.com/globalize/globalize/blob/master/lib/globalize/active_record/instance_methods.rb 10 line.
So, I had one issue with optimization. Globalize rewrote this method and make request for getting new translated attributes from *_translations table. So, when I tried to optimize MyModel.includes(:translation), I had too many request.
So I think it would be good alternative for this issue.