### PR TITLE
Do not update unloaded state for Sequel:

### DIFF
--- a/lib/aasm/persistence/sequel_persistence.rb
+++ b/lib/aasm/persistence/sequel_persistence.rb
@@ -72,6 +72,7 @@ module AASM
         #
         def aasm_ensure_initial_state
           aasm.enter_initial_state if
+            (new? || values.key?(self.class.aasm.attribute_name)) &&
             send(self.class.aasm.attribute_name).to_s.strip.empty?
         end
 

--- a/spec/unit/persistence/sequel_persistence_spec.rb
+++ b/spec/unit/persistence/sequel_persistence_spec.rb
@@ -44,6 +44,11 @@ describe 'sequel' do
         expect(model.aasm.current_state).to eq(:alpha)
       end
 
+      it "should save the initial state" do
+        model.save
+        expect(model.status).to eq("alpha")
+      end
+
       it "should return the aasm column when new and the aasm field is not nil" do
         model.status = "beta"
         expect(model.aasm.current_state).to eq(:beta)
@@ -59,6 +64,14 @@ describe 'sequel' do
         allow(model).to receive(:new?).and_return(false)
         model.status = nil
         expect(model.aasm.current_state).to be_nil
+      end
+
+      it "should not change the state if state is not loaded" do
+        model.release
+        model.save
+        model.class.select(:id).first.save
+        model.reload
+        expect(model.aasm.current_state).to eq(:beta)
       end
 
       it "should call aasm_ensure_initial_state on validation before create" do


### PR DESCRIPTION
The problem is that the record might already have a state, which was
just not loaded due to explicit `select'. In this case, AASM should not
try to write the initial state into database.