### PR TITLE
Passing event arguments into state callbacks

### DIFF
--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -69,8 +69,10 @@ private
       )
 
       if may_fire_to = event.may_fire?(self, *args)
-        old_state.fire_callbacks(:before_exit, self)
-        old_state.fire_callbacks(:exit, self) # TODO: remove for AASM 4?
+        old_state.fire_callbacks(:before_exit, self,
+          *process_args(event, aasm.current_state, *args))
+        old_state.fire_callbacks(:exit, self,
+          *process_args(event, aasm.current_state, *args)) # TODO: remove for AASM 4?
 
         if new_state_name = event.fire(self, {:may_fire => may_fire_to}, *args)
           aasm_fired(event, old_state, new_state_name, options, *args, &block)
@@ -90,9 +92,11 @@ private
 
     new_state = aasm.state_object_for_name(new_state_name)
 
-    new_state.fire_callbacks(:before_enter, self)
+    new_state.fire_callbacks(:before_enter, self,
+      *process_args(event, aasm.current_state, *args))
 
-    new_state.fire_callbacks(:enter, self) # TODO: remove for AASM 4?
+    new_state.fire_callbacks(:enter, self,
+      *process_args(event, aasm.current_state, *args)) # TODO: remove for AASM 4?
 
     persist_successful = true
     if persist
@@ -107,8 +111,10 @@ private
     end
 
     if persist_successful
-      old_state.fire_callbacks(:after_exit, self)
-      new_state.fire_callbacks(:after_enter, self)
+      old_state.fire_callbacks(:after_exit, self,
+        *process_args(event, aasm.current_state, *args))
+      new_state.fire_callbacks(:after_enter, self,
+        *process_args(event, aasm.current_state, *args))
       event.fire_callbacks(
         :after,
         self,

--- a/lib/aasm/core/state.rb
+++ b/lib/aasm/core/state.rb
@@ -28,12 +28,12 @@ module AASM::Core
       name.to_s
     end
 
-    def fire_callbacks(action, record)
+    def fire_callbacks(action, record, *args)
       action = @options[action]
       catch :halt_aasm_chain do
         action.is_a?(Array) ?
-                action.each {|a| _fire_callbacks(a, record)} :
-                _fire_callbacks(action, record)
+                action.each {|a| _fire_callbacks(a, record, args)} :
+                _fire_callbacks(action, record, args)
       end
     end
 
@@ -66,12 +66,14 @@ module AASM::Core
       self
     end
 
-    def _fire_callbacks(action, record)
+    def _fire_callbacks(action, record, args)
       case action
         when Symbol, String
-          record.send(action)
+          arity = record.send(:method, action.to_sym).arity
+          record.send(action, *(arity < 0 ? args : args[0...arity]))
         when Proc
-          action.call(record)
+          arity = action.arity
+          action.call(record, *(arity < 0 ? args : args[0...arity]))
       end
     end
 

--- a/spec/models/callbacks/with_args.rb
+++ b/spec/models/callbacks/with_args.rb
@@ -44,15 +44,15 @@ module Callbacks
 
     def aasm_write_state(*args); log('aasm_write_state'); true; end
 
-    def before_enter_open; log('before_enter_open'); end
-    def before_exit_open; log('before_exit_open'); end
-    def after_enter_open; log('after_enter_open'); end
-    def after_exit_open; log('after_exit_open'); end
+    def before_enter_open(*args); log("before_enter_open(#{args.map(&:inspect).join(',')})"); end
+    def before_exit_open(*args); log("before_exit_open(#{args.map(&:inspect).join(',')})"); end
+    def after_enter_open(*args); log("after_enter_open(#{args.map(&:inspect).join(',')})"); end
+    def after_exit_open(*args); log("after_exit_open(#{args.map(&:inspect).join(',')})"); end
 
-    def before_enter_closed; log('before_enter_closed'); end
-    def before_exit_closed; log('before_enter_closed'); end
-    def after_enter_closed; log('after_enter_closed'); end
-    def after_exit_closed; log('after_exit_closed'); end
+    def before_enter_closed(*args); log("before_enter_closed(#{args.map(&:inspect).join(',')})"); end
+    def before_exit_closed(*args); log("before_enter_closed(#{args.map(&:inspect).join(',')})"); end
+    def after_enter_closed(*args); log("after_enter_closed(#{args.map(&:inspect).join(',')})"); end
+    def after_exit_closed(*args); log("after_exit_closed(#{args.map(&:inspect).join(',')})"); end
 
     def before(arg1, *args); log("before(#{arg1.inspect},#{args.map(&:inspect).join(',')})"); end
     def transition_proc(arg1, arg2); log("transition_proc(#{arg1.inspect},#{arg2.inspect})"); end

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -145,7 +145,7 @@ describe 'callbacks for the new DSL' do
 
     cb.reset_data
     cb.close!(:arg1, :arg2)
-    expect(cb.data).to eql 'before(:arg1,:arg2) before_exit_open transition_proc(:arg1,:arg2) before_enter_closed aasm_write_state after_exit_open after_enter_closed after(:arg1,:arg2)'
+    expect(cb.data).to eql 'before(:arg1,:arg2) before_exit_open(:arg1,:arg2) transition_proc(:arg1,:arg2) before_enter_closed(:arg1,:arg2) aasm_write_state after_exit_open(:arg1,:arg2) after_enter_closed(:arg1,:arg2) after(:arg1,:arg2)'
   end
 
   it "should call the callbacks given the to-state as argument" do


### PR DESCRIPTION
I found it useful to also pass the arguments of events into the state callbacks. I was hoping to get it merged back if you see a general use for this.

My scenario is that I have a state which always needs some checks to be done (and takes some optional arguments). I could add the checks to every event into that state. A cleaner way would be to also pass the arguments into these callbacks I think.