### PR TITLE
add ability to merge options for a state instead of erase the previous one

### DIFF
--- a/lib/aasm/core/state.rb
+++ b/lib/aasm/core/state.rb
@@ -28,6 +28,24 @@ module AASM::Core
       name.to_s
     end
 
+    # This merge will append new callbacks from the options to the state
+    # if the state already have a after_enter and the options contains a after_enter callback
+    # the state will have the list of callbacks to execute
+    def merge(options={})
+      @display_name = options.delete(:display_name) if options.key? :display_name
+
+      options.each do |action, callback|
+        if @options.has_key?(action)
+          existing_callbacks = @options[action]
+          existing_callbacks = [existing_callbacks] unless existing_callbacks.is_a?(Array)
+          @options[action] = (existing_callbacks << callback).flatten
+        else
+          @options[action] = callback
+        end
+      end
+      self
+    end
+
     def fire_callbacks(action, record, *args)
       action = @options[action]
       catch :halt_aasm_chain do

--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -29,10 +29,12 @@ module AASM
     def add_state(name, klass, options)
       set_initial_state(name, options)
 
-      # allow reloading, extending or redefining a state
-      @states.delete(name) if @states.include?(name)
-
-      @states << AASM::Core::State.new(name, klass, options)
+      if @states.include?(name)
+        # Merge the new options to the existing state
+        @states[@states.find_index(name)].merge options
+      else
+        @states << AASM::Core::State.new(name, klass, options)
+      end
     end
 
     private


### PR DESCRIPTION
When adding a state two times, the second erase the first one, this can be a bit embarrassing in some case, like a global state machine is defined as a concern and each classe add there own specific states or events and so would like to connect to the callbacks of some existing states.

Now it's so possible to cumulate the states like
```
state :created, after_enter: :do_something, before_enter: :before_enter_callback
state :created, after_enter: :do_something_else
```
this will be the same than 
```
state :created, before_enter: before_enter_callback, after_enter: [:do_something, :do_something_else]
```
instead of actually just 
```
state :created, after_enter: :do_something_else
```