### PR TITLE
reuse respond_to? to be able to check (for rails >= 4.x) if the state attribute exists (even if it's not in the model attributes)

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -164,9 +164,8 @@ module AASM
         #   foo.aasm_state # => nil
         #
         def aasm_ensure_initial_state
-          # checking via respond_to? does not work in Rails <= 3
-          # if respond_to?(self.class.aasm.attribute_name) && send(self.class.aasm.attribute_name).blank? # Rails 4
-          if attribute_names.include?(self.class.aasm.attribute_name.to_s) && send(self.class.aasm.attribute_name).blank?
+          has_attribute = Rails::VERSION::MAJOR > 3 ? respond_to?(self.class.aasm.attribute_name) : attribute_names.include?(self.class.aasm.attribute_name.to_s)
+          if has_attribute && send(self.class.aasm.attribute_name).blank?
             aasm.enter_initial_state
           end
         end


### PR DESCRIPTION
When using a state attribute which is not a column in active record model we can't initialize the state. This case can append when using a kind of alias method instead of use the column config when define the aasm or (in my case) using a multi table inheritance gem like active_record-acts_as where the parent class contains the state attribute. In that case, the model don't have this attribute but respond to the getter and setter method.

Of course this fix only for Rails 4+