### PR TITLE
pass args to after_commit callbacks

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -176,7 +176,7 @@ module AASM
 
           if success && options[:persist]
             event = self.class.aasm.state_machine.events[name]
-            event.fire_callbacks(:after_commit, self)
+            event.fire_callbacks(:after_commit, self, *args)
           end
 
           success

--- a/spec/models/validator.rb
+++ b/spec/models/validator.rb
@@ -12,8 +12,8 @@ class Validator < ActiveRecord::Base
       transitions :to => :running, :from => :sleeping
     end
     event :sleep do
-      after_commit do
-        change_name_on_sleep
+      after_commit do |name|
+        change_name_on_sleep name
       end
       transitions :to => :sleeping, :from => :running
     end
@@ -29,8 +29,8 @@ class Validator < ActiveRecord::Base
     save!
   end
 
-  def change_name_on_sleep
-    self.name = "sleeper"
+  def change_name_on_sleep name
+    self.name = name
     save!
   end
 

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -454,7 +454,7 @@ describe 'transitions with persistence' do
         expect(validator).to be_running
         expect(validator.name).to eq("name changed")
 
-        validator.sleep!
+        validator.sleep!("sleeper")
         expect(validator).to be_sleeping
         expect(validator.name).to eq("sleeper")
       end


### PR DESCRIPTION
Currently, any args passed into an event are not passed on to the `after_commit` callbacks. This PR allows args to be passed in.