### PR TITLE
Remove @klass.table_name from scope conditions key

### DIFF
--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -82,7 +82,7 @@ module AASM
 
     def create_for_active_record(name)
       conditions = {
-        @klass.table_name => { @klass.aasm(@name).attribute_name => name.to_s }
+        @klass.aasm.attribute_name => name.to_s
       }
       if ActiveRecord::VERSION::MAJOR >= 3
         @klass.class_eval do


### PR DESCRIPTION
If we remove @klass.table_name, definded scope works well,
because ActiveRecord dose not need table name to define scope.

And `"#{@klass.table_name}.#{@klass.aasm.attribute_name}"` dose
not work well when we set database name to `table_name`.