### PR TITLE
enh(aasm): patches failing and edge cases in supporting multiple AASMs

### DIFF
--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -35,7 +35,7 @@ module AASM
       def aasm_read_state(name=:default)
         state = send(self.class.aasm(name).attribute_name)
         if new_record?
-          state.blank? ? aasm.determine_state_name(self.class.aasm(name).initial_state) : state.to_sym
+          state.blank? ? aasm(name).determine_state_name(self.class.aasm(name).initial_state) : state.to_sym
         else
           state.blank? ? nil : state.to_sym
         end


### PR DESCRIPTION
- fixes `AASM::Persistence::Base#aasm_read_state` not reading with the correct name
- I may have other fixes that are required for this feature to work for our app

:recycle: https://github.com/aasm/aasm/pull/240