### PR TITLE
Updates 'Callbacks' section example to be correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ class Job
     state :running
 
     event :run, :after => :notify_somebody do
-      transitions :from => :sleeping, :to => :running, :after => Proc.new {|*args| set_process(*args) } do
-        before do
-          log('Preparing to run')
-        end
+      before do
+        log('Preparing to run')
       end
+
+      transitions :from => :sleeping, :to => :running, :after => Proc.new {|*args| set_process(*args) }
     end
 
     event :sleep do


### PR DESCRIPTION
The current example is trying to define a before block inside of a
transition block, which is not a supported callback.  Moving the before
block in to the event block for an example that is supported.