### PR TITLE
Allow namespacing methods and state constants

### DIFF
--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -19,5 +19,8 @@ module AASM
     attr_accessor :no_direct_assignment
 
     attr_accessor :enum
+
+    # namespace reader methods and constants
+    attr_accessor :namespace
   end
 end

--- a/spec/models/namespaced_multiple_example.rb
+++ b/spec/models/namespaced_multiple_example.rb
@@ -1,0 +1,28 @@
+class NamespacedMultipleExample
+  include AASM
+  aasm(:status) do
+    state :unapproved, :initial => true
+    state :approved
+
+    event :approve do
+      transitions :from => :unapproved, :to => :approved
+    end
+
+    event :unapprove do
+      transitions :from => :approved, :to => :unapproved
+    end
+  end
+
+  aasm(:review_status, namespace: :review) do
+    state :unapproved, :initial => true
+    state :approved
+
+    event :approve_review do
+      transitions :from => :unapproved, :to => :approved
+    end
+
+    event :unapprove_review do
+      transitions :from => :approved, :to => :unapproved
+    end
+  end
+end

--- a/spec/unit/namespaced_multiple_example_spec.rb
+++ b/spec/unit/namespaced_multiple_example_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'state machine' do
+  let(:namespaced) { NamespacedMultipleExample.new }
+
+  it 'starts with an initial state' do
+    expect(namespaced.aasm(:status).current_state).to eq(:unapproved)
+    expect(namespaced).to respond_to(:unapproved?)
+    expect(namespaced).to be_unapproved
+
+    expect(namespaced.aasm(:review_status).current_state).to eq(:unapproved)
+    expect(namespaced).to respond_to(:review_unapproved?)
+    expect(namespaced).to be_review_unapproved
+  end
+
+  it 'allows transitions to other states' do
+    expect(namespaced).to respond_to(:approve)
+    expect(namespaced).to respond_to(:approve!)
+    namespaced.approve!
+    expect(namespaced).to respond_to(:approved?)
+    expect(namespaced).to be_approved
+
+    expect(namespaced).to respond_to(:approve_review)
+    expect(namespaced).to respond_to(:approve_review!)
+    namespaced.approve_review!
+    expect(namespaced).to respond_to(:review_approved?)
+    expect(namespaced).to be_review_approved
+  end
+
+  it 'denies transitions to other states' do
+    expect {namespaced.unapprove}.to raise_error(AASM::InvalidTransition)
+    expect {namespaced.unapprove!}.to raise_error(AASM::InvalidTransition)
+    namespaced.approve
+    expect {namespaced.approve}.to raise_error(AASM::InvalidTransition)
+    expect {namespaced.approve!}.to raise_error(AASM::InvalidTransition)
+    namespaced.unapprove
+
+    expect {namespaced.unapprove_review}.to raise_error(AASM::InvalidTransition)
+    expect {namespaced.unapprove_review!}.to raise_error(AASM::InvalidTransition)
+    namespaced.approve_review
+    expect {namespaced.approve_review}.to raise_error(AASM::InvalidTransition)
+    expect {namespaced.approve_review!}.to raise_error(AASM::InvalidTransition)
+    namespaced.unapprove_review
+  end
+
+  it 'defines constants for each state name' do
+    expect(NamespacedMultipleExample::STATE_UNAPPROVED).to eq(:unapproved)
+    expect(NamespacedMultipleExample::STATE_APPROVED).to eq(:approved)
+
+    expect(NamespacedMultipleExample::STATE_REVIEW_UNAPPROVED).to eq(:unapproved)
+    expect(NamespacedMultipleExample::STATE_REVIEW_APPROVED).to eq(:approved)
+  end
+end


### PR DESCRIPTION
Proof of concept. In a nutshell, I want to have multiple state machines use the same states without conflicting (e.g. `status={unapproved,approved}`, `review_status={unapproved,approved}`). As a simple start, I added a `namespace` configuration option, which if set to true for `review_status` would define `review_status_unapproved?` and `review_status_approved`, as well as `STATE_REVIEW_STATUS_UNAPPROVED` and `STATE_REVIEW_STATUS_APPROVED`.

If this isn't the right approach, I'm happy to explore other ways of accomplishing the same goal.