### PR TITLE
Raise 'column_name undefined error' when column not present

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -96,7 +96,10 @@ module AASM
         end
 
         def aasm_column_looks_like_enum(name=:default)
-          self.class.columns_hash[self.class.aasm(name).attribute_name.to_s].type == :integer
+          column_name = self.class.aasm(name).attribute_name.to_s
+          column = self.class.columns_hash[column_name]
+          raise NoMethodError.new("undefined method '#{column_name}' for #{self.class}") if column.nil?
+          column.type == :integer
         end
 
         def aasm_guess_enum_method(name=:default)

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Migration.suppress_messages do
-  %w{gates multiple_gates readers writers transients simples no_scopes multiple_no_scopes no_direct_assignments multiple_no_direct_assignments thieves multiple_thieves localizer_test_models persisted_states provided_and_persisted_states with_enums with_true_enums with_false_enums false_states multiple_with_enums multiple_with_true_enums multiple_with_false_enums multiple_false_states readme_jobs}.each do |table_name|
+  %w{gates multiple_gates readers writers transients simples no_scopes multiple_no_scopes no_direct_assignments multiple_no_direct_assignments thieves multiple_thieves localizer_test_models persisted_states provided_and_persisted_states with_enums with_enum_without_columns multiple_with_enum_without_columns with_true_enums with_false_enums false_states multiple_with_enums multiple_with_true_enums multiple_with_false_enums multiple_false_states readme_jobs}.each do |table_name|
     ActiveRecord::Migration.create_table table_name, :force => true do |t|
       t.string "aasm_state"
     end

--- a/spec/models/active_record/with_enum_without_column.rb
+++ b/spec/models/active_record/with_enum_without_column.rb
@@ -1,0 +1,35 @@
+class WithEnumWithoutColumn < ActiveRecord::Base
+  include AASM
+
+  enum status: {
+    opened: 0,
+    closed: 1
+  }
+
+  aasm :column => :status do
+    state :closed, initial: true
+    state :opened
+
+    event :view do
+      transitions :to => :opened, :from => :closed
+    end
+  end
+end
+
+class MultipleWithEnumWithoutColumn < ActiveRecord::Base
+  include AASM
+
+  enum status: {
+    opened: 0,
+    closed: 1
+  }
+
+  aasm :left, :column => :status do
+    state :closed, initial: true
+    state :opened
+
+    event :view do
+      transitions :to => :opened, :from => :closed
+    end
+  end
+end

--- a/spec/models/active_record/with_enum_without_column.rb
+++ b/spec/models/active_record/with_enum_without_column.rb
@@ -1,10 +1,12 @@
 class WithEnumWithoutColumn < ActiveRecord::Base
   include AASM
 
-  enum status: {
-    opened: 0,
-    closed: 1
-  }
+  if ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 1 # won't work with Rails <= 4.1
+    enum status: {
+      opened: 0,
+      closed: 1
+    }
+  end
 
   aasm :column => :status do
     state :closed, initial: true
@@ -18,11 +20,12 @@ end
 
 class MultipleWithEnumWithoutColumn < ActiveRecord::Base
   include AASM
-
-  enum status: {
-    opened: 0,
-    closed: 1
-  }
+  if ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 1 # won't work with Rails <= 4.1
+    enum status: {
+      opened: 0,
+      closed: 1
+    }
+  end
 
   aasm :left, :column => :status do
     state :closed, initial: true

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -113,6 +113,17 @@ describe "instance methods" do
         end
       end
     end
+    
+    context "when AASM enum setting is not enabled and aasm column not present" do
+      before :each do
+        @multiple_with_enum_with_column = MultipleWithEnumWithoutColumn.new
+      end
+      
+      it "should raise NoMethodError for transitions" do
+        expect{@multiple_with_enum_with_column.send(:view, :left)}.to raise_error(NoMethodError, "undefined method 'status' for MultipleWithEnumWithoutColumn")  
+      end
+    end
+
   end
 
   context "when AASM is configured to use enum" do

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -113,15 +113,18 @@ describe "instance methods" do
         end
       end
     end
-    
-    context "when AASM enum setting is not enabled and aasm column not present" do
-      before :each do
-        @multiple_with_enum_with_column = MultipleWithEnumWithoutColumn.new
+
+    if ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 1 # won't work with Rails <= 4.1
+      # Enum are introduced from Rails 4.1, therefore enum syntax will not work on Rails <= 4.1
+      context "when AASM enum setting is not enabled and aasm column not present" do
+
+        let(:multiple_with_enum_without_column) {MultipleWithEnumWithoutColumn.new}
+
+        it "should raise NoMethodError for transitions" do
+          expect{multiple_with_enum_without_column.send(:view, :left)}.to raise_error(NoMethodError, "undefined method 'status' for MultipleWithEnumWithoutColumn")
+        end
       end
-      
-      it "should raise NoMethodError for transitions" do
-        expect{@multiple_with_enum_with_column.send(:view, :left)}.to raise_error(NoMethodError, "undefined method 'status' for MultipleWithEnumWithoutColumn")  
-      end
+
     end
 
   end

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -114,14 +114,17 @@ describe "instance methods" do
       end
     end
 
-    context "when AASM enum setting is not enabled and aasm column not present" do
-      before :each do
-        @with_enum_with_column = WithEnumWithoutColumn.new
+    if ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 1 # won't work with Rails <= 4.1
+      # Enum are introduced from Rails 4.1, therefore enum syntax will not work on Rails <= 4.1
+      context "when AASM enum setting is not enabled and aasm column not present" do
+
+        let(:with_enum_without_column) {WithEnumWithoutColumn.new}
+
+        it "should raise NoMethodError for transitions" do
+          expect{with_enum_without_column.send(:view)}.to raise_error(NoMethodError, "undefined method 'status' for WithEnumWithoutColumn")
+        end
       end
-      
-      it "should raise NoMethodError for transitions" do
-        expect{@with_enum_with_column.send(:view)}.to raise_error(NoMethodError, "undefined method 'status' for WithEnumWithoutColumn")  
-      end
+
     end
 
   end

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -113,6 +113,17 @@ describe "instance methods" do
         end
       end
     end
+
+    context "when AASM enum setting is not enabled and aasm column not present" do
+      before :each do
+        @with_enum_with_column = WithEnumWithoutColumn.new
+      end
+      
+      it "should raise NoMethodError for transitions" do
+        expect{@with_enum_with_column.send(:view)}.to raise_error(NoMethodError, "undefined method 'status' for WithEnumWithoutColumn")  
+      end
+    end
+
   end
 
   context "when AASM is configured to use enum" do


### PR DESCRIPTION
When using enum for state column and enum config not set explicitly,
if column is not present in database then "NoMethodError: undefined
method 'type' for nil:NilClass" was raised for transitions which is
hard to debug.
Fix #152