### PR TITLE
Support for global transition callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 4.4.0 (not yet released)
+
+ * add support global transation callbacks (see [issue #221](https://github.com/aasm/aasm/issues/221) and [issue #253](https://github.com/aasm/aasm/issues/253) for details)
+
 ## 4.3.0
 
  * add support for multiple state machines per class (see [issue #158](https://github.com/aasm/aasm/issues/158) and [issue #240](https://github.com/aasm/aasm/issues/240) for details)

--- a/PLANNED_CHANGES.md
+++ b/PLANNED_CHANGES.md
@@ -4,7 +4,10 @@
 
    * drop support for aasm_column ?
 
+
 # Currently working on
+
+   * support for global callbacks (see #221 and #253)
 
 
 # Changes so far

--- a/PLANNED_CHANGES.md
+++ b/PLANNED_CHANGES.md
@@ -7,24 +7,5 @@
 
 # Currently working on
 
-   * support for global callbacks (see #221 and #253)
-
 
 # Changes so far
-
-## version 4.3
-
- * add support for multiple state machines per class
-   * class- and instance-level `aasm` methods accept a state machine selector
-     (aka the state machine _name_)
-     * if no selector/name is provided, `:default` will be used
-   * duplicate definitions of states and events will issue warnings
-   * check all tests
-     * _ActiveRecord_
-     * _Mongoid_
-     * _MongoMapper_
-     * _Sequel_
-   * what happen's if someone accesses `aasm`, but has defined a
-     state machine for `aasm(:my_name)`?
-   * documentation
- * drop support for find_in_state, count_in_state, calculate_in_state, with_state_scope

--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ simple.aasm(:work).current
 
 ```
 
-_AASM_ doesn't prohibit to define the same event in both state machines. The
-latest definition "wins" and overrides previous definitions. A warning is issued:
-`SimpleMultipleExample: The event name run is already used!`.
+_AASM_ doesn't prohibit to define the same event in more than one state machine. The
+latest definition "wins" and overrides previous definitions. Nonetheless, a warning is issued:
+`SimpleMultipleExample: The aasm event name run is already used!`.
 
 All _AASM_ class- and instance-level `aasm` methods accept a state machine selector.
 So, for example, to use inspection on a class level, you have to use
@@ -378,7 +378,7 @@ SimpleMultipleExample.aasm(:work).states
 ```
 
 *Final note*: Support for multiple state machines per class is a pretty new feature
-(since version `4.3`), so please bear with us in case it doesn't as expected.
+(since version `4.3`), so please bear with us in case it doesn't work as expected.
 
 
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ class Job
     state :sleeping, :initial => true, :before_enter => :do_something
     state :running
 
+    after_all_transitions :log_status_change
+
     event :run, :after => :notify_somebody do
       before do
         log('Preparing to run')
@@ -115,6 +117,10 @@ class Job
       end
       transitions :from => :running, :to => :sleeping
     end
+  end
+
+  def log_status_change
+    puts "changing from #{aasm.from_state} to #{aasm.to_state} (event: #{aasm.current_event})"
   end
 
   def set_process(name)
@@ -145,6 +151,7 @@ begin
   transition      guards
   old_state       before_exit
   old_state       exit
+                  after_all_transitions
   transition      after
   new_state       before_enter
   new_state       enter
@@ -172,8 +179,9 @@ Note that when passing arguments to a state transition, the first argument must 
 In case of an error during the event processing the error is rescued and passed to `:error`
 callback, which can handle it or re-raise it for further propagation.
 
-During the transition's `:after` callback (and reliably only then) you can access the
-originating state (the from-state) and the target state (the to state), like this:
+During the transition's `:after` callback (and reliably only then, or in the global
+`after_all_transitions` callback) you can access the originating state (the from-state)
+and the target state (the to state), like this:
 
 ```ruby
   def set_process(name)

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -109,6 +109,10 @@ module AASM
       EORUBY
     end
 
+    def after_all_transitions(*callbacks, &block)
+      @state_machine.add_global_callbacks(:after_all_transitions, *callbacks, &block)
+    end
+
     def states
       @state_machine.states
     end

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -67,7 +67,7 @@ module AASM
       @state_machine.add_state(name, @klass, options)
 
       if @klass.instance_methods.include?("#{name}?")
-        warn "#{@klass.name}: The state name #{name} is already used!"
+        warn "#{@klass.name}: The aasm state name #{name} is already used!"
       end
 
       @klass.class_eval <<-EORUBY, __FILE__, __LINE__ + 1
@@ -86,7 +86,7 @@ module AASM
       @state_machine.add_event(name, options, &block)
 
       if @klass.instance_methods.include?("may_#{name}?".to_sym)
-        warn "#{@klass.name}: The event name #{name} is already used!"
+        warn "#{@klass.name}: The aasm event name #{name} is already used!"
       end
 
       # an addition over standard aasm so that, before firing an event, you can ask

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -30,6 +30,7 @@ module AASM::Core
     end
 
     def execute(obj, *args)
+      invoke_callbacks_compatible_with_guard(event.state_machine.global_callbacks[:after_all_transitions], obj, args)
       invoke_callbacks_compatible_with_guard(@after, obj, args)
     end
 

--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -10,12 +10,13 @@ module AASM
       (@machines ||= {})[klass.to_s] = machine
     end
 
-    attr_accessor :states, :events, :initial_state, :config, :name
+    attr_accessor :states, :events, :initial_state, :config, :name, :global_callbacks
 
     def initialize(name)
       @initial_state = nil
       @states = []
       @events = {}
+      @global_callbacks = {}
       @config = AASM::Configuration.new
       @name = name
     end
@@ -38,6 +39,14 @@ module AASM
 
     def add_event(name, options, &block)
       @events[name] = AASM::Core::Event.new(name, self, options, &block)
+    end
+
+    def add_global_callbacks(name, *callbacks, &block)
+      @global_callbacks[name] ||= []
+      callbacks.each do |callback|
+        @global_callbacks[name] << callback
+      end
+      @global_callbacks[name] << block if block
     end
 
     private

--- a/spec/models/callbacks/basic.rb
+++ b/spec/models/callbacks/basic.rb
@@ -18,6 +18,8 @@ module Callbacks
     end
 
     aasm do
+      after_all_transitions :after_all_transitions
+
       state :open, :initial => true,
         :before_enter => :before_enter_open,
         :enter        => :enter_open,
@@ -68,6 +70,7 @@ module Callbacks
     def transition_guard;     log('transition_guard');    !@fail_transition_guard; end
 
     def after_transition;     log('after_transition');    end
+    def after_all_transitions;log('after_all_transitions');end
 
     def before_event;         log('before_event');        end
     def after_event;          log('after_event');         end

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -17,6 +17,7 @@ describe 'callbacks for the new DSL' do
       expect(callback).to receive(:exit_open).once.ordered
       # expect(callback).to receive(:event_guard).once.ordered.and_return(true)
       # expect(callback).to receive(:transition_guard).once.ordered.and_return(true)
+      expect(callback).to receive(:after_all_transitions).once.ordered
       expect(callback).to receive(:after_transition).once.ordered
       expect(callback).to receive(:before_enter_closed).once.ordered
       expect(callback).to receive(:enter_closed).once.ordered


### PR DESCRIPTION
Example:

```ruby
class Job
  include AASM

  aasm do
    state :sleeping, :initial => true, :before_enter => :do_something
    state :running

    after_all_transitions :log_status_change
    ...
  end

  def log_status_change
    puts "changing from #{aasm.from_state} to #{aasm.to_state} (event: #{aasm.current_event})"
  end
end
```