### PR TITLE
Add a new option to the events method to reject specific events before testing for permitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,8 @@ job.aasm.states(:permitted => true).map(&:name)
 # show all possible (triggerable) events (allowed by transitions)
 job.aasm.events.map(&:name)
 => [:sleep]
+job.aasm.events(:reject => :sleep).map(&:name)
+=> []
 
 # list states for select
 Job.aasm.states_for_select

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -49,8 +49,7 @@ module AASM
       state = options[:state] || current_state
       events = @instance.class.aasm(@name).events.select {|e| e.transitions_from_state?(state) }
 
-      options[:reject] = Array(options[:reject])
-      events.reject!{|e| (options[:reject] || []).include?(e.name)}
+      events.reject!{|e| Array(options[:reject]).include?(e.name)}
 
       if options[:permitted]
         # filters the results of events_for_current_state so that only those that

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -49,6 +49,9 @@ module AASM
       state = options[:state] || current_state
       events = @instance.class.aasm(@name).events.select {|e| e.transitions_from_state?(state) }
 
+      options[:reject] = [options[:reject]] if options[:reject].is_a? Symbol
+      events.reject!{|e| (options[:reject] || []).include?(e.name)}
+
       if options[:permitted]
         # filters the results of events_for_current_state so that only those that
         # are really currently possible (given transition guards) are shown.

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -49,7 +49,8 @@ module AASM
       state = options[:state] || current_state
       events = @instance.class.aasm(@name).events.select {|e| e.transitions_from_state?(state) }
 
-      events.reject!{|e| Array(options[:reject]).include?(e.name)}
+      options[:reject] = Array(options[:reject])
+      events.reject! { |e| options[:reject].include?(e.name) }
 
       if options[:permitted]
         # filters the results of events_for_current_state so that only those that

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -49,7 +49,7 @@ module AASM
       state = options[:state] || current_state
       events = @instance.class.aasm(@name).events.select {|e| e.transitions_from_state?(state) }
 
-      options[:reject] = [options[:reject]] if options[:reject].is_a? Symbol
+      options[:reject] = Array(options[:reject])
       events.reject!{|e| (options[:reject] || []).include?(e.name)}
 
       if options[:permitted]

--- a/spec/unit/inspection_spec.rb
+++ b/spec/unit/inspection_spec.rb
@@ -103,4 +103,9 @@ describe 'permitted events' do
     expect(foo.aasm.events(:permitted => true)).to include(:close)
     expect(foo.aasm.events(:permitted => true)).not_to include(:null)
   end
+
+  it 'should not include events in the reject option' do
+    expect(foo.aasm.events(:permitted => true, reject: :close)).not_to include(:close)
+    expect(foo.aasm.events(:permitted => true, reject: [:close])).not_to include(:close)
+  end
 end


### PR DESCRIPTION
We had an issue in our codebase where calling `events(permitted: true)` was causing an infinite loop because one of the events had a guard that called a method that called the method calling the above code.

Our solution was to create this fork and pass in the offending event in the `reject` parameter. I'd assume other people may find this handy as well.

Let me know what you think.