### PR TITLE
New Callbacks - Transactions, All Events, Ensure

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,17 @@ Since version *3.0.13* AASM supports ActiveRecord transactions. So whenever a tr
 callback or the state update fails, all changes to any database record are rolled back.
 Mongodb does not support transactions.
 
+There are currently 3 transactional callbacks that can be handled on the event, and 2 transactional callbacks for all events.
+
+```ruby
+  event           before_all_transactions
+  event           before_transaction
+  event           aasm_fire_event (within transaction)
+  event           after_commit (if event successful)
+  event           after_transaction
+  event           after_all_transactions
+```
+
 If you want to make sure a depending action happens only after the transaction is committed,
 use the `after_commit` callback, like this:
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Here you can see a list of all possible callbacks, together with their order of 
 
 ```ruby
 begin
+  event           before_all_events
   event           before
   event           guards
   transition      guards
@@ -160,8 +161,13 @@ begin
   old_state       after_exit
   new_state       after_enter
   event           after
+  event           after_all_events
 rescue
   event           error
+  event           error_on_all_events
+ensure
+  event           ensure
+  event           ensure_on_all_events
 end
 ```
 

--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -103,12 +103,12 @@ private
         aasm_failed(state_machine_name, event_name, old_state)
       end
     rescue StandardError => e
-      event.fire_callbacks(:error, self, e, *process_args(event, aasm(state_machine_name).current_state, *args)) || 
+      event.fire_callbacks(:error, self, e, *process_args(event, aasm(state_machine_name).current_state, *args)) ||
       event.fire_global_callbacks(:error_on_all_events, self, e, *process_args(event, aasm(state_machine_name).current_state, *args)) ||
       raise(e)
     ensure
       event.fire_callbacks(:ensure, self, *process_args(event, aasm(state_machine_name).current_state, *args))
-      event.fire_global_callbacks(:ensure_on_all_events, self, *process_args(event, aasm(state_machine_name).current_state, *args)) 
+      event.fire_global_callbacks(:ensure_on_all_events, self, *process_args(event, aasm(state_machine_name).current_state, *args))
     end
   end
 

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -113,6 +113,22 @@ module AASM
       @state_machine.add_global_callbacks(:after_all_transitions, *callbacks, &block)
     end
 
+    def before_all_events(*callbacks, &block)
+      @state_machine.add_global_callbacks(:before_all_events, *callbacks, &block)
+    end
+
+    def after_all_events(*callbacks, &block)
+      @state_machine.add_global_callbacks(:after_all_events, *callbacks, &block)
+    end
+
+    def error_on_all_events(*callbacks, &block)
+      @state_machine.add_global_callbacks(:error_on_all_events, *callbacks, &block)
+    end
+
+    def ensure_on_all_events(*callbacks, &block)
+      @state_machine.add_global_callbacks(:ensure_on_all_events, *callbacks, &block)
+    end
+
     def states
       @state_machine.states
     end

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -113,6 +113,14 @@ module AASM
       @state_machine.add_global_callbacks(:after_all_transitions, *callbacks, &block)
     end
 
+    def after_all_transactions(*callbacks, &block)
+      @state_machine.add_global_callbacks(:after_all_transactions, *callbacks, &block)
+    end
+
+    def before_all_transactions(*callbacks, &block)
+      @state_machine.add_global_callbacks(:before_all_transactions, *callbacks, &block)
+    end
+
     def before_all_events(*callbacks, &block)
       @state_machine.add_global_callbacks(:before_all_events, *callbacks, &block)
     end

--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -13,7 +13,16 @@ module AASM::Core
 
       # from aasm4
       @options = options # QUESTION: .dup ?
-      add_options_from_dsl(@options, [:after, :before, :error, :success, :after_commit, :ensure], &block) if block
+      add_options_from_dsl(@options, [
+        :after,
+        :after_commit,
+        :after_transaction,
+        :before,
+        :before_transaction,
+        :ensure,
+        :error,
+        :success,
+      ], &block) if block
     end
 
     # a neutered version of fire - it doesn't actually fire the event, it just

--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -13,7 +13,7 @@ module AASM::Core
 
       # from aasm4
       @options = options # QUESTION: .dup ?
-      add_options_from_dsl(@options, [:after, :before, :error, :success, :after_commit], &block) if block
+      add_options_from_dsl(@options, [:after, :before, :error, :success, :after_commit, :ensure], &block) if block
     end
 
     # a neutered version of fire - it doesn't actually fire the event, it just
@@ -41,6 +41,10 @@ module AASM::Core
 
     def transitions_to_state(state)
       @transitions.select { |t| t.to == state }
+    end
+
+    def fire_global_callbacks(callback_name, record, *args)
+      invoke_callbacks(state_machine.global_callbacks[callback_name], record, args)
     end
 
     def fire_callbacks(callback_name, record, *args)
@@ -145,6 +149,5 @@ module AASM::Core
           false
       end
     end
-
   end
 end # AASM

--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -145,11 +145,24 @@ module AASM
         end
 
         def aasm_fire_event(state_machine_name, name, options, *args, &block)
-          success = options[:persist] ? self.class.transaction(:requires_new => requires_new?(state_machine_name)) { super } : super
+          event = self.class.aasm(state_machine_name).state_machine.events[name]
 
-          if success && options[:persist]
-            event = self.class.aasm(state_machine_name).state_machine.events[name]
-            event.fire_callbacks(:after_commit, self, *args)
+          if options[:persist]
+            event.fire_callbacks(:before_transaction, self, *args)
+            event.fire_global_callbacks(:before_all_transactions, self, *args)
+          end
+
+          begin
+            success = options[:persist] ? self.class.transaction(:requires_new => requires_new?(state_machine_name)) { super } : super
+            if options[:persist] && success
+              event.fire_callbacks(:after_commit, self, *args)
+              event.fire_global_callbacks(:after_all_commits, self, *args)
+            end
+          ensure
+            if options[:persist]
+              event.fire_callbacks(:after_transaction, self, *args)
+              event.fire_global_callbacks(:after_all_transactions, self, *args)
+            end
           end
 
           success

--- a/spec/models/callbacks/basic.rb
+++ b/spec/models/callbacks/basic.rb
@@ -18,7 +18,10 @@ module Callbacks
     end
 
     aasm do
-      after_all_transitions :after_all_transitions
+      before_all_events       :before_all_events
+      after_all_events        :after_all_events
+      ensure_on_all_events    :ensure_on_all_events
+      after_all_transitions   :after_all_transitions
 
       state :open, :initial => true,
         :before_enter => :before_enter_open,
@@ -36,11 +39,11 @@ module Callbacks
         :exit         => :exit_closed,
         :after_exit   => :after_exit_closed
 
-      event :close, :before => :before_event, :after => :after_event, :guard => :event_guard do
+      event :close, :before => :before_event, :after => :after_event, :guard => :event_guard, :ensure => :ensure_event do
         transitions :to => :closed, :from => [:open], :guard => :transition_guard, :after => :after_transition
       end
 
-      event :open, :before => :before_event, :after => :after_event do
+      event :open, :before => :before_event, :after => :after_event  do
         transitions :to => :open, :from => :closed
       end
     end
@@ -50,29 +53,33 @@ module Callbacks
       puts text if @log
     end
 
-    def aasm_write_state(*args); log('aasm_write_state'); true; end
+    def aasm_write_state(*args);  log('aasm_write_state'); true;  end
+    def before_enter_open;        log('before_enter_open');       end
+    def enter_open;               log('enter_open');              end
+    def before_exit_open;         log('before_exit_open');        end
+    def after_enter_open;         log('after_enter_open');        end
+    def exit_open;                log('exit_open');               end
+    def after_exit_open;          log('after_exit_open');         end
 
-    def before_enter_open;    log('before_enter_open');   end
-    def enter_open;           log('enter_open');          end
-    def before_exit_open;     log('before_exit_open');    end
-    def after_enter_open;     log('after_enter_open');    end
-    def exit_open;            log('exit_open');           end
-    def after_exit_open;      log('after_exit_open');     end
+    def before_enter_closed;      log('before_enter_closed'); end
+    def enter_closed;             log('enter_closed');        end
+    def before_exit_closed;       log('before_exit_closed');  end
+    def exit_closed;              log('exit_closed');         end
+    def after_enter_closed;       log('after_enter_closed');  end
+    def after_exit_closed;        log('after_exit_closed');   end
 
-    def before_enter_closed;  log('before_enter_closed'); end
-    def enter_closed;         log('enter_closed');        end
-    def before_exit_closed;   log('before_exit_closed');  end
-    def exit_closed;          log('exit_closed');         end
-    def after_enter_closed;   log('after_enter_closed');  end
-    def after_exit_closed;    log('after_exit_closed');   end
+    def event_guard;              log('event_guard');         !@fail_event_guard;      end
+    def transition_guard;         log('transition_guard');    !@fail_transition_guard; end
 
-    def event_guard;          log('event_guard');         !@fail_event_guard;      end
-    def transition_guard;     log('transition_guard');    !@fail_transition_guard; end
+    def after_transition;         log('after_transition');        end
+    def after_all_transitions;    log('after_all_transitions');   end
 
-    def after_transition;     log('after_transition');    end
-    def after_all_transitions;log('after_all_transitions');end
+    def before_all_events;        log('before_all_events')    end
+    def before_event;             log('before_event');        end
+    def after_event;              log('after_event');         end
+    def after_all_events;         log('after_all_events');    end
 
-    def before_event;         log('before_event');        end
-    def after_event;          log('after_event');         end
+    def ensure_event;             log('ensure');              end
+    def ensure_on_all_events;     log('ensure');              end
   end
 end

--- a/spec/models/foo.rb
+++ b/spec/models/foo.rb
@@ -1,16 +1,19 @@
-class Foo
-  include AASM
-  aasm do
-    state :open, :initial => true, :before_exit => :before_exit
-    state :closed, :before_enter => :before_enter
-    state :final
+module Fooable
+  def self.included(base)
+    base.class_eval do
+      aasm do
+        state :open, :initial => true, :before_exit => :before_exit
+        state :closed, :before_enter => :before_enter
+        state :final
 
-    event :close, :success => :success_callback do
-      transitions :from => [:open], :to => [:closed]
-    end
+        event :close, :success => :success_callback do
+          transitions :from => [:open], :to => [:closed]
+        end
 
-    event :null do
-      transitions :from => [:open], :to => [:closed, :final], :guard => :always_false
+        event :null do
+          transitions :from => [:open], :to => [:closed, :final], :guard => :always_false
+        end
+      end
     end
   end
 
@@ -23,8 +26,19 @@ class Foo
 
   def before_enter
   end
+
   def before_exit
   end
+end
+
+class Foo
+  include AASM
+  include Fooable
+end
+
+class FooGlobal
+  include AASM
+  include Fooable
 end
 
 class FooTwo < Foo

--- a/spec/models/validator.rb
+++ b/spec/models/validator.rb
@@ -2,22 +2,46 @@ require 'active_record'
 
 class Validator < ActiveRecord::Base
 
+  attr_accessor :after_transaction_performed_on_fail,
+    :after_transaction_performed_on_run,
+    :before_transaction_performed_on_fail,
+    :before_transaction_performed_on_run
+
   include AASM
+
   aasm :column => :status do
     state :sleeping, :initial => true
     state :running
     state :failed, :after_enter => :fail
 
     event :run, :after_commit => :change_name! do
+      after_transaction do
+        @after_transaction_performed_on_run = true
+      end
+
+      before_transaction do
+        @before_transaction_performed_on_run = true
+      end
+
       transitions :to => :running, :from => :sleeping
     end
+
     event :sleep do
       after_commit do |name|
         change_name_on_sleep name
       end
       transitions :to => :sleeping, :from => :running
     end
+
     event :fail do
+      after_transaction do
+        @after_transaction_performed_on_fail = true
+      end
+
+      before_transaction do
+        @before_transaction_performed_on_fail = true
+      end
+
       transitions :to => :failed, :from => [:sleeping, :running]
     end
   end

--- a/spec/models/validator.rb
+++ b/spec/models/validator.rb
@@ -1,15 +1,19 @@
 require 'active_record'
 
 class Validator < ActiveRecord::Base
-
-  attr_accessor :after_transaction_performed_on_fail,
+  attr_accessor :after_all_transactions_performed,
+    :after_transaction_performed_on_fail,
     :after_transaction_performed_on_run,
+    :before_all_transactions_performed,
     :before_transaction_performed_on_fail,
     :before_transaction_performed_on_run
 
   include AASM
 
   aasm :column => :status do
+    before_all_transactions :before_all_transactions
+    after_all_transactions  :after_all_transactions
+
     state :sleeping, :initial => true
     state :running
     state :failed, :after_enter => :fail
@@ -60,6 +64,14 @@ class Validator < ActiveRecord::Base
 
   def fail
     raise StandardError.new('failed on purpose')
+  end
+
+  def after_all_transactions
+    @after_all_transactions_performed = true
+  end
+
+  def before_all_transactions
+    @before_all_transactions_performed = true
   end
 end
 

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -1,6 +1,65 @@
 require 'spec_helper'
 Dir[File.dirname(__FILE__) + "/../models/callbacks/*.rb"].sort.each { |f| require File.expand_path(f) }
 
+shared_examples 'an implemented callback that accepts error' do
+  context 'with callback defined' do
+    it "should run error_callback if an exception is raised" do
+      aasm_model.class.send(:define_method, callback_name) do |e|
+        @data = [e]
+      end
+
+      allow(aasm_model).to receive(:before_enter).and_raise(e = StandardError.new)
+
+      aasm_model.safe_close!
+      expect(aasm_model.data).to eql [e]
+    end
+
+    it "should run error_callback without parameters if callback does not support any" do
+      aasm_model.class.send(:define_method, callback_name) do |e|
+        @data = []
+      end
+
+      allow(aasm_model).to receive(:before_enter).and_raise(e = StandardError.new)
+
+      aasm_model.safe_close!('arg1', 'arg2')
+      expect(aasm_model.data).to eql []
+    end
+
+    it "should run error_callback with parameters if callback supports them" do
+      aasm_model.class.send(:define_method, callback_name) do |e, arg1, arg2|
+        @data = [arg1, arg2]
+      end
+
+      allow(aasm_model).to receive(:before_enter).and_raise(e = StandardError.new)
+
+      aasm_model.safe_close!('arg1', 'arg2')
+      expect(aasm_model.data).to eql ['arg1', 'arg2']
+    end
+  end
+end
+
+shared_examples 'an implemented callback' do
+  context 'with callback defined' do
+    it 'should run callback without parameters if callback does not support any' do
+      aasm_model.class.send(:define_method, callback_name) do
+        @data = ['callback-was-called']
+      end
+
+      aasm_model.safe_close!
+      expect(aasm_model.data).to eql ['callback-was-called']
+    end
+
+    it 'should run callback with parameters if callback supports them' do
+      aasm_model.class.send(:define_method, callback_name) do |arg1, arg2|
+        @data = [arg1, arg2]
+      end
+
+      aasm_model.safe_close!('arg1', 'arg2')
+      expect(aasm_model.data).to eql ['arg1', 'arg2']
+    end
+  end
+end
+
 describe 'callbacks for the new DSL' do
 
   it "be called in order" do
@@ -10,6 +69,7 @@ describe 'callbacks for the new DSL' do
     callback.aasm.current_state
 
     unless show_debug_log
+      expect(callback).to receive(:before_all_events).once.ordered
       expect(callback).to receive(:before_event).once.ordered
       expect(callback).to receive(:event_guard).once.ordered.and_return(true)
       expect(callback).to receive(:transition_guard).once.ordered.and_return(true)
@@ -25,6 +85,9 @@ describe 'callbacks for the new DSL' do
       expect(callback).to receive(:after_exit_open).once.ordered                    # these should be after the state changes
       expect(callback).to receive(:after_enter_closed).once.ordered
       expect(callback).to receive(:after_event).once.ordered
+      expect(callback).to receive(:after_all_events).once.ordered
+      expect(callback).to receive(:ensure_event).once.ordered
+      expect(callback).to receive(:ensure_on_all_events).once.ordered
     end
 
     # puts "------- close!"
@@ -35,11 +98,13 @@ describe 'callbacks for the new DSL' do
     callback = Callbacks::Basic.new(:log => false)
     callback.aasm.current_state
 
+    expect(callback).to receive(:before_all_events).once.ordered    
     expect(callback).to receive(:before_event).once.ordered
     expect(callback).to receive(:event_guard).once.ordered.and_return(false)
     expect(callback).to_not receive(:transition_guard)
     expect(callback).to_not receive(:before_exit_open)
     expect(callback).to_not receive(:exit_open)
+    expect(callback).to_not receive(:after_all_transitions)
     expect(callback).to_not receive(:after_transition)
     expect(callback).to_not receive(:before_enter_closed)
     expect(callback).to_not receive(:enter_closed)
@@ -47,6 +112,9 @@ describe 'callbacks for the new DSL' do
     expect(callback).to_not receive(:after_exit_open)
     expect(callback).to_not receive(:after_enter_closed)
     expect(callback).to_not receive(:after_event)
+    expect(callback).to_not receive(:after_all_events)
+    expect(callback).to receive(:ensure_event).once.ordered
+    expect(callback).to receive(:ensure_on_all_events).once.ordered
 
     expect {
       callback.close!
@@ -72,11 +140,13 @@ describe 'callbacks for the new DSL' do
       callback.aasm.current_state
 
       unless show_debug_log
+        expect(callback).to receive(:before_all_events).once.ordered
         expect(callback).to receive(:before_event).once.ordered
         expect(callback).to receive(:event_guard).once.ordered.and_return(true)
         expect(callback).to receive(:transition_guard).once.ordered.and_return(false)
         expect(callback).to_not receive(:before_exit_open)
         expect(callback).to_not receive(:exit_open)
+        expect(callback).to_not receive(:after_all_transitions)
         expect(callback).to_not receive(:after_transition)
         expect(callback).to_not receive(:before_enter_closed)
         expect(callback).to_not receive(:enter_closed)
@@ -84,6 +154,9 @@ describe 'callbacks for the new DSL' do
         expect(callback).to_not receive(:after_exit_open)
         expect(callback).to_not receive(:after_enter_closed)
         expect(callback).to_not receive(:after_event)
+        expect(callback).to_not receive(:after_all_events)
+        expect(callback).to receive(:ensure_event).once.ordered
+        expect(callback).to receive(:ensure_on_all_events).once.ordered
       end
 
       expect {
@@ -201,39 +274,9 @@ describe 'event callbacks' do
       @foo = Foo.new
     end
 
-    context "error_callback defined" do
-      it "should run error_callback if an exception is raised" do
-        def @foo.error_callback(e)
-          @data = [e]
-        end
-
-        allow(@foo).to receive(:before_enter).and_raise(e = StandardError.new)
-
-        @foo.safe_close!
-        expect(@foo.data).to eql [e]
-      end
-
-      it "should run error_callback without parameters if callback does not support any" do
-        def @foo.error_callback(e)
-          @data = []
-        end
-
-        allow(@foo).to receive(:before_enter).and_raise(e = StandardError.new)
-
-        @foo.safe_close!('arg1', 'arg2')
-        expect(@foo.data).to eql []
-      end
-
-      it "should run error_callback with parameters if callback supports them" do
-        def @foo.error_callback(e, arg1, arg2)
-          @data = [arg1, arg2]
-        end
-
-        allow(@foo).to receive(:before_enter).and_raise(e = StandardError.new)
-
-        @foo.safe_close!('arg1', 'arg2')
-        expect(@foo.data).to eql ['arg1', 'arg2']
-      end
+    it_behaves_like 'an implemented callback that accepts error' do
+      let(:aasm_model) { @foo }
+      let(:callback_name) { :error_callback }
     end
 
     it "should raise NoMethodError if exception is raised and error_callback is declared but not defined" do
@@ -242,8 +285,39 @@ describe 'event callbacks' do
     end
 
     it "should propagate an error if no error callback is declared" do
-        allow(@foo).to receive(:before_enter).and_raise("Cannot enter safe")
-        expect{@foo.close!}.to raise_error(StandardError, "Cannot enter safe")
+      allow(@foo).to receive(:before_enter).and_raise("Cannot enter safe")
+      expect{@foo.close!}.to raise_error(StandardError, "Cannot enter safe")
+    end
+  end
+
+  describe 'with an ensure callback defined' do
+    before do
+      class Foo
+        # this hack is needed to allow testing of parameters, since RSpec
+        # destroys a method's arity when mocked
+        attr_accessor :data
+
+        aasm do
+          event :safe_close, :success => :success_callback, :ensure => :ensure_callback do
+            transitions :to => :closed, :from => [:open]
+          end
+        end
+      end
+
+      @foo = Foo.new
+    end
+
+    it_behaves_like 'an implemented callback' do
+      let(:aasm_model) { @foo }
+      let(:callback_name) { :ensure_callback }
+    end
+
+    it "should raise NoMethodError if ensure_callback is declared but not defined" do
+      expect{@foo.safe_close!}.to raise_error(NoMethodError)
+    end
+
+    it "should not raise any error if no ensure_callback is declared" do
+      expect{@foo.close!}.to_not raise_error
     end
   end
 
@@ -292,5 +366,76 @@ describe 'event callbacks' do
       @foo.close!
     end
   end
+end
 
+describe 'global error_on_all_events_callback callbacks' do
+  describe "with an error_on_all_events" do
+    before do
+      class Foo
+        # this hack is needed to allow testing of parameters, since RSpec
+        # destroys a method's arity when mocked
+        attr_accessor :data
+
+        aasm do
+          error_on_all_events  :error_on_all_events_callback
+
+          event :safe_close do
+            transitions :to => :closed, :from => [:open]
+          end
+        end
+      end
+
+      @foo = Foo.new
+    end
+
+    it_behaves_like 'an implemented callback that accepts error' do
+      let(:aasm_model) { @foo }
+      let(:callback_name) { :error_on_all_events_callback } 
+    end
+
+    it "should raise NoMethodError if exception is raised and error_callback is declared but not defined" do
+      allow(@foo).to receive(:before_enter).and_raise(StandardError)
+      expect{@foo.safe_close!}.to raise_error(NoMethodError)
+    end
+
+    it "should raise NoMethodError if no error callback is declared" do
+      allow(@foo).to receive(:before_enter).and_raise("Cannot enter safe")
+      expect{@foo.close!}.to raise_error(NoMethodError)
+    end
+  end
+end
+
+describe 'global ensure_on_all_events_callback callbacks' do
+  describe "with an ensure_on_all_events" do
+    before do
+      class Foo
+        # this hack is needed to allow testing of parameters, since RSpec
+        # destroys a method's arity when mocked
+        attr_accessor :data
+
+        aasm do
+          ensure_on_all_events  :ensure_on_all_events_callback
+
+          event :safe_close do
+            transitions :to => :closed, :from => [:open]
+          end
+        end
+      end
+
+      @foo = Foo.new
+    end
+
+    it_behaves_like 'an implemented callback' do
+      let(:aasm_model) { @foo }
+      let(:callback_name) { :ensure_on_all_events_callback }
+    end
+
+    it "should raise NoMethodError if ensure_on_all_events callback is declared but not defined" do
+      expect{@foo.safe_close!}.to raise_error(NoMethodError)
+    end
+
+    it "should raise NoMethodError if no ensure_on_all_events callback is declared" do
+      expect{@foo.close!}.to raise_error(NoMethodError)
+    end
+  end
 end

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -98,7 +98,7 @@ describe 'callbacks for the new DSL' do
     callback = Callbacks::Basic.new(:log => false)
     callback.aasm.current_state
 
-    expect(callback).to receive(:before_all_events).once.ordered    
+    expect(callback).to receive(:before_all_events).once.ordered
     expect(callback).to receive(:before_event).once.ordered
     expect(callback).to receive(:event_guard).once.ordered.and_return(false)
     expect(callback).to_not receive(:transition_guard)
@@ -371,7 +371,7 @@ end
 describe 'global error_on_all_events_callback callbacks' do
   describe "with an error_on_all_events" do
     before do
-      class Foo
+      class FooGlobal
         # this hack is needed to allow testing of parameters, since RSpec
         # destroys a method's arity when mocked
         attr_accessor :data
@@ -385,12 +385,12 @@ describe 'global error_on_all_events_callback callbacks' do
         end
       end
 
-      @foo = Foo.new
+      @foo = FooGlobal.new
     end
 
     it_behaves_like 'an implemented callback that accepts error' do
       let(:aasm_model) { @foo }
-      let(:callback_name) { :error_on_all_events_callback } 
+      let(:callback_name) { :error_on_all_events_callback }
     end
 
     it "should raise NoMethodError if exception is raised and error_callback is declared but not defined" do
@@ -408,7 +408,7 @@ end
 describe 'global ensure_on_all_events_callback callbacks' do
   describe "with an ensure_on_all_events" do
     before do
-      class Foo
+      class FooGlobal
         # this hack is needed to allow testing of parameters, since RSpec
         # destroys a method's arity when mocked
         attr_accessor :data
@@ -422,7 +422,7 @@ describe 'global ensure_on_all_events_callback callbacks' do
         end
       end
 
-      @foo = Foo.new
+      @foo = FooGlobal.new
     end
 
     it_behaves_like 'an implemented callback' do

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -468,7 +468,39 @@ describe 'transitions with persistence' do
         expect(validator).to be_running
         expect(validator.name).to eq("name")
       end
+    end
 
+    describe 'before and after transaction callbacks' do
+      [:after, :before].each do |event_type|
+        describe "before_transaction callback" do
+          it "should fire :#{event_type}_transaction if transaction was successful" do
+            validator = Validator.create(:name => 'name')
+            expect(validator).to be_sleeping
+
+            expect { validator.run! }.to change { validator.send("#{event_type}_transaction_performed_on_run") }.from(nil).to(true)
+            expect(validator).to be_running
+          end
+
+          it "should fire :before_transaction if transaction failed" do
+            validator = Validator.create(:name => 'name')
+            expect do
+              begin
+                validator.fail!
+              rescue => ignored
+              end
+            end.to change { validator.send("#{event_type}_transaction_performed_on_fail") }.from(nil).to(true)
+            expect(validator).to_not be_running
+          end
+
+          it "should not fire if not saving" do
+            validator = Validator.create(:name => 'name')
+            expect(validator).to be_sleeping
+            expect { validator.run }.to_not change { validator.send("#{event_type}_transaction_performed_on_run") }
+            expect(validator).to be_running
+            expect(validator.name).to eq("name")
+          end
+        end
+      end
     end
 
     context "when not persisting" do

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -472,7 +472,7 @@ describe 'transitions with persistence' do
 
     describe 'before and after transaction callbacks' do
       [:after, :before].each do |event_type|
-        describe "before_transaction callback" do
+        describe "#{event_type}_transaction callback" do
           it "should fire :#{event_type}_transaction if transaction was successful" do
             validator = Validator.create(:name => 'name')
             expect(validator).to be_sleeping
@@ -481,7 +481,7 @@ describe 'transitions with persistence' do
             expect(validator).to be_running
           end
 
-          it "should fire :before_transaction if transaction failed" do
+          it "should fire :#{event_type}_transaction if transaction failed" do
             validator = Validator.create(:name => 'name')
             expect do
               begin
@@ -492,10 +492,43 @@ describe 'transitions with persistence' do
             expect(validator).to_not be_running
           end
 
-          it "should not fire if not saving" do
+          it "should not fire :#{event_type}_transaction if not saving" do
             validator = Validator.create(:name => 'name')
             expect(validator).to be_sleeping
             expect { validator.run }.to_not change { validator.send("#{event_type}_transaction_performed_on_run") }
+            expect(validator).to be_running
+            expect(validator.name).to eq("name")
+          end
+        end
+      end
+    end
+
+    describe 'before and after all transactions callbacks' do
+      [:after, :before].each do |event_type|
+        describe "#{event_type}_all_transactions callback" do
+          it "should fire :#{event_type}_all_transactions if transaction was successful" do
+            validator = Validator.create(:name => 'name')
+            expect(validator).to be_sleeping
+
+            expect { validator.run! }.to change { validator.send("#{event_type}_all_transactions_performed") }.from(nil).to(true)
+            expect(validator).to be_running
+          end
+
+          it "should fire :#{event_type}_all_transactions if transaction failed" do
+            validator = Validator.create(:name => 'name')
+            expect do
+              begin
+                validator.fail!
+              rescue => ignored
+              end
+            end.to change { validator.send("#{event_type}_all_transactions_performed") }.from(nil).to(true)
+            expect(validator).to_not be_running
+          end
+
+          it "should not fire :#{event_type}_all_transactions if not saving" do
+            validator = Validator.create(:name => 'name')
+            expect(validator).to be_sleeping
+            expect { validator.run }.to_not change { validator.send("#{event_type}_all_transactions_performed") }
             expect(validator).to be_running
             expect(validator.name).to eq("name")
           end


### PR DESCRIPTION
This PR takes advantage of the global callback foundation introduced in https://github.com/aasm/aasm/pull/270 for ```after_all_transitions```.

In particular, it introduces the following new global events.

* ```before_all_events```, invoked before ```event before```
* ```after_all_events```, invoked after ```event after```
* ```error_on_all_events```, invoked after ```event error```
* ```ensure_on_all_events```, invoked after ```event ensure```
* ```before_all_transactions```, invoked before ```event before_transaction```
* ```before_transaction```, invoked before ```before_aasm_fire_event```
* ```after_transaction```, involved after ```event after_commit``` regardless of success
* ```after_all_transactions```, invoked after ```event after_transaction```

For completeness, a new event level callback was added to compliment ```ensure_on_all_events```.

* ```ensure```, invoked on any ```event``` regardless of completion or error.

This allows AASM to handle like a standard ruby before/rescue/ensure.

The inspiration for this carries from #270, which I believe, is to help DRY up our various callbacks in our state machines.

For example, we wanted to track every time we entered and exited a state (we had to hide it from a AASM workflow GUI). The brute force way was to add ```before``` and ```after``` hooks on every event like so and hope we nailed everything.

### Brute Force

Here's what I think it would look like with current AASM.

```
class Job
  include AASM
  aasm do
    state :sleeping, :initial => true
    state :running
    state :cleaning

    event :run, before: :transitioning_on, after: :transitioning_off, error: transitioning_off  do
      transitions :from => :sleeping, :to => :running
    end

    event :clean, before: :transitioning_on, after: :transitioning_off, error: transitioning_off  do
      transitions :from => :running, :to => :cleaning
    end

    event :sleep, before: :transitioning_on, after: :transitioning_off, error: transitioning_off do
      transitions :from => [:running, :cleaning], :to => :sleeping
    end

    def transitioning_on
      update_columns(is_transitioning: true)
    end

    def transitioning_off
      update_columns(is_transitioning: false)
    end
  end
end
```

### Monkey Patching

We decided to get clever and instead attack it within  ```aasm_fire_event```.

```
    def aasm_fire_event(event_name, options, *args, &block)
      update_columns(is_transitioning: true)
      super
    ensure
      update_columns(is_transitioning: false)
    end
```
### A Better Way ?

But with the work in #270 and this PR, we can do the following and stop monkey patching into AASM.

```
class Job
  include AASM
  aasm do
    before_all_events :transitioning_on
    ensure_on_all_events :transitioning_off

    event :run do
      transitions :from => :sleeping, :to => :running
    end

    event :clean do
      transitions :from => :running, :to => :cleaning
    end

    event :sleep do
      transitions :from => [:running, :cleaning], :to => :sleeping
    end
  end

  def transitioning_on
    update_columns(is_transitioning: true)
  end

  def transitioning_off
    update_columns(is_transitioning: false)
  end
end
```

If we feel this is the right direction, I'll be happy to add follow up commits with the appropriate documentation changes. At this point, I'm just stumbling behind the hard work done in #270.

UPDATE: I changed the direction of this PR significantly, but I am still stumbling....