### PR TITLE
Introduce Pessimistic Locking For AR Persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,41 @@ end
 
 which then leads to `transaction(:requires_new => false)`, the Rails default.
 
+### Pessimistic Locking
+
+AASM supports [Active Record pessimistic locking via `with_lock`](http://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html#method-i-with_lock) for database persistence layers.
+
+| Option | Purpose |
+| ------ | ------- |
+| `false` (default) | No lock is obtained | |
+| `true` | Obtain a blocking pessimistic lock e.g. `FOR UPDATE` |
+| String | Obtain a lock based on the SQL string e.g. `FOR UPDATE NOWAIT` |
+
+
+```ruby
+class Job < ActiveRecord::Base
+  include AASM
+
+  aasm :requires_lock => true do
+    ...
+  end
+
+  ...
+end
+```
+
+```ruby
+class Job < ActiveRecord::Base
+  include AASM
+
+  aasm :requires_lock => 'FOR UPDATE NOWAIT' do
+    ...
+  end
+
+  ...
+end
+```
+
 
 ### Column name & migration
 

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -24,6 +24,11 @@ module AASM
       # use requires_new for nested transactions (in ActiveRecord)
       configure :requires_new_transaction, true
 
+      # use pessimistic locking (in ActiveRecord)
+      # true for FOR UPDATE lock
+      # string for a specific lock type i.e. FOR UPDATE NOWAIT
+      configure :requires_lock, false
+
       # set to true to forbid direct assignment of aasm_state column (in ActiveRecord)
       configure :no_direct_assignment, false
 

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -15,6 +15,9 @@ module AASM
     # for ActiveRecord: use requires_new for nested transactions?
     attr_accessor :requires_new_transaction
 
+    # for ActiveRecord: use pessimistic locking
+    attr_accessor :requires_lock
+
     # forbid direct assignment in aasm_state column (in ActiveRecord)
     attr_accessor :no_direct_assignment
 

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -17,24 +17,19 @@ ActiveRecord::Migration.suppress_messages do
     t.string "right"
   end
 
-  ActiveRecord::Migration.create_table "validators", :force => true do |t|
-    t.string "name"
-    t.string "status"
-  end
-  ActiveRecord::Migration.create_table "multiple_validators", :force => true do |t|
-    t.string "name"
-    t.string "status"
+  %w(validators multiple_validators).each do |table_name|
+    ActiveRecord::Migration.create_table table_name, :force => true do |t|
+      t.string "name"
+      t.string "status"
+    end
   end
 
-  ActiveRecord::Migration.create_table "transactors", :force => true do |t|
-    t.string "name"
-    t.string "status"
-    t.integer "worker_id"
-  end
-  ActiveRecord::Migration.create_table "multiple_transactors", :force => true do |t|
-    t.string "name"
-    t.string "status"
-    t.integer "worker_id"
+  %w(transactors no_lock_transactors lock_transactors lock_no_wait_transactors multiple_transactors).each do |table_name|
+    ActiveRecord::Migration.create_table table_name, :force => true do |t|
+      t.string "name"
+      t.string "status"
+      t.integer "worker_id"
+    end
   end
 
   ActiveRecord::Migration.create_table "workers", :force => true do |t|

--- a/spec/models/transactor.rb
+++ b/spec/models/transactor.rb
@@ -26,6 +26,54 @@ private
 
 end
 
+class NoLockTransactor < ActiveRecord::Base
+
+  belongs_to :worker
+
+  include AASM
+
+  aasm :column => :status do
+    state :sleeping, :initial => true
+    state :running
+
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+  end
+end
+
+class LockTransactor < ActiveRecord::Base
+
+  belongs_to :worker
+
+  include AASM
+
+  aasm :column => :status, requires_lock: true do
+    state :sleeping, :initial => true
+    state :running
+
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+  end
+end
+
+class LockNoWaitTransactor < ActiveRecord::Base
+
+  belongs_to :worker
+
+  include AASM
+
+  aasm :column => :status, requires_lock: 'FOR UPDATE NOWAIT' do
+    state :sleeping, :initial => true
+    state :running
+
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+  end
+end
+
 class MultipleTransactor < ActiveRecord::Base
 
   belongs_to :worker


### PR DESCRIPTION
I understand there has been a previous conversation where we felt that it wasn't appropriate to have pessimistic locking within AASM.

https://github.com/aasm/aasm/issues/230

I offer this PR to revisit the conversation. It adds a ```requires_lock``` configuration to AASM. When set to true or some SQL string i.e. ```FOR UPDATE NOWAIT```, it will be passed through to ActiveRecord's ```lock!``` method. This will allow our AASM models to transition knowing that it owns the row lock and not in contention with another resource that is also accessing the model. It also allows any ```guard``` callbacks we have on the AASM model to operate on the latest data, vs potentially un-committed data if in a PostGres MVCC type of environment.

Our AASM project has fallen into the same pattern as this article by Engine Yard, https://blog.engineyard.com/2010/concurrency-and-the-aasm-gem; we are constantly locking an AASM model in a controller, and potentially in a lower level facade/service layer as we introduce non HTTP touch points to our AASM models (Jobs, Console, other POROs, other AASM models). I'm wondering if this pattern gets ameliorated if we tried to offer locking within AASM.

In summary, it's becoming slightly untenable for us to continue to lock at the controller entry point when thee are so many points of contention.

#### An Example

Using the simple Job example from the README with the lock

```
class Job < ActiveRecord::Base
  include AASM

  aasm requires_lock: 'FOR UPDATE NOWAIT' do
    state :sleeping, :initial => true
    state :running
    state :cleaning

    event :run do
      transitions :from => :sleeping, :to => :running
    end

    event :clean do
      transitions :from => :running, :to => :cleaning
    end

    event :sleep do
      transitions :from => [:running, :cleaning], :to => :sleeping
    end
  end
end
```

####  Locking With No Conflict

Note the FOR UPDATE NOWAIT query reload of the model.

```
irb(main):002:0> j.run!
   (0.8ms)  BEGIN
  Job Load (0.9ms)  SELECT  "jobs".* FROM "jobs"  WHERE "jobs"."id" = $1 LIMIT 1 FOR UPDATE NOWAIT  [["id", 3]]
  SQL (0.3ms)  UPDATE "jobs" SET "aasm_state" = $1, "updated_at" = $2 WHERE "jobs"."id" = 3  [["aasm_state", "running"], ["updated_at", "2015-11-06 17:57:33.939470"]]
   (6.1ms)  COMMIT
=> true
```

#### With A Conflict

console 1
```
irb(main):001:0> Job.find(3).with_lock { sleep 10000000 } 
```

console 2
```
rb(main):005:0> j.run!
   (0.3ms)  BEGIN
  Job Load (1.8ms)  SELECT  "jobs".* FROM "jobs"  WHERE "jobs"."id" = $1 LIMIT 1 FOR UPDATE NOWAIT  [["id", 3]]
PG::Error: ERROR:  could not obtain lock on row in relation "jobs"
: SELECT  "jobs".* FROM "jobs"  WHERE "jobs"."id" = $1 LIMIT 1 FOR UPDATE NOWAIT
   (0.3ms)  ROLLBACK
ActiveRecord::StatementInvalid: PG::Error: ERROR:  could not obtain lock on row in relation "jobs"
: SELECT  "jobs".* FROM "jobs"  WHERE "jobs"."id" = $1 LIMIT 1 FOR UPDATE NOWAIT
```

Related Documents
http://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html