### PR TITLE
allow multiple states to be defined on one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ class Job
 
   aasm do
     state :sleeping, :initial => true
-    state :running
-    state :cleaning
+    state :running, :cleaning
 
     event :run do
       transitions :from => :sleeping, :to => :running

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -79,8 +79,6 @@ module AASM
     # [1..] state
     def state(*args)
       names, options = interpret_state_args(args)
-      puts names.inspect
-      puts options.inspect
       names.each do |name|
         @state_machine.add_state(name, klass, options)
 

--- a/spec/models/states_on_one_line_example.rb
+++ b/spec/models/states_on_one_line_example.rb
@@ -1,0 +1,8 @@
+class StatesOnOneLineExample
+  include AASM
+
+  aasm :one_line do
+    state :initial, :initial => true
+    state :first, :second
+  end
+end

--- a/spec/unit/readme_spec.rb
+++ b/spec/unit/readme_spec.rb
@@ -8,8 +8,7 @@ describe 'testing the README examples' do
 
       aasm do
         state :sleeping, :initial => true
-        state :running
-        state :cleaning
+        state :running, :cleaning
 
         event :run do
           transitions :from => :sleeping, :to => :running

--- a/spec/unit/states_on_one_line_example_spec.rb
+++ b/spec/unit/states_on_one_line_example_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe StatesOnOneLineExample do
+  let(:example) { StatesOnOneLineExample.new }
+  describe 'on initialize' do
+    it 'should be in the initial state' do
+      expect(example.aasm(:one_line).current_state).to eql :initial
+    end
+  end
+
+  describe 'states' do
+    it 'should have all 3 states defined' do
+      expect(example.aasm(:one_line).states.map(&:name)).to eq [:initial, :first, :second]
+    end
+  end
+end


### PR DESCRIPTION
resolves #146

I don't know if anyone still wants it, but it was straight forward enough to add.

I hope you don't mind I coopted the first example in the readme to show the new syntax. I am happy to change that if you prefer it done differently.

*Question:* The issue also mentioned being able to refer to multiple states by `states` rather than `state` in the `aasm` block, however `states` as defined in base is already accessible from that scope as we just instance_eval the block against the base class. I was wondering if you would be open to scoping the methods that are callable from the aasm block to some subset of the methods in base. I am happy to create an issue and take a look.