### PR TITLE
use attribute name as symbol in hash, without table name, for activerecord scopes

### DIFF
--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -82,7 +82,7 @@ module AASM
 
     def create_for_active_record(name)
       conditions = {
-        "#{@klass.table_name}.#{@klass.aasm(@name).attribute_name}" => name.to_s
+        @klass.table_name => { @klass.aasm(@name).attribute_name => name.to_s }
       }
       if ActiveRecord::VERSION::MAJOR >= 3
         @klass.class_eval do


### PR DESCRIPTION
I have self.table_name = 'database.table' in my AASM model, because I do sharding and change database connected on ActiveRecord::Base on every request, but for AASM model I want to use the main database always, so I set in the table name so I don't need to establish new connection.

However, setting conditions with "#{@klass.table_name}.#{@klass.aasm(@name).attribute_name}" generates wrong SQL:

```sql
`database`.`table_name.status`, instead of `database`.`table_name`.`status`
```

If conditions uses column name as symbol, such as {:status => name.to_s}, activerecord generates right SQL, including table name (and database in my case).