### PR TITLE
Make It Easier To Extend AASM With Custom Logic Across Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,71 @@ SimpleMultipleExample.aasm(:work).states
 *Final note*: Support for multiple state machines per class is a pretty new feature
 (since version `4.3`), so please bear with us in case it doesn't work as expected.
 
+### Extending AASM
+
+AASM allows you to easily extend `AASM::Base` for your own application purposes.
+
+Let's suppose we have common logic across many AASM models. We can embody this logic in a sub-class of `AASM::Base`.
+
+```
+class CustomAASMBase < AASM::Base
+  # A custom transiton that we want available across many AASM models.
+  def count_transitions!
+    klass.class_eval do
+      aasm_with CustomAASMBase do
+        after_all_transitions :increment_transition_count
+      end
+    end
+  end
+
+  # A custom annotation that we want available across many AASM models.
+  def requires_guards!
+    klass.class_eval do
+      attr_reader :authorizable_called,
+        :transition_count,
+        :fillable_called
+
+      def authorizable?
+        @authorizable_called = true
+      end
+
+      def fillable?
+        @fillable_called = true
+      end
+
+      def increment_transition_count
+        @transition_count ||= 0
+        @transition_count += 1
+      end
+    end
+  end
+end
+```
+
+When we declare our model that has an AASM state machine, we simply declare the AASM block with `aasm_with` to our own class.
+
+```
+class SimpleCustomExample
+  include AASM
+
+  # Let's build an AASM state machine with our custom class.
+  aasm_with CustomAASMBase do
+    requires_guards!
+    count_transitions!
+
+    state :initialised, :initial => true
+    state :filled_out
+    state :authorised
+
+    event :fill_out do
+      transitions :from => :initialised, :to => :filled_out, :guard => :fillable?
+    end
+    event :authorise do
+      transitions :from => :filled_out, :to => :authorised, :guard => :authorizable?
+    end
+  end
+end
+```
 
 
 ### ActiveRecord

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ class CustomAASMBase < AASM::Base
   # A custom transiton that we want available across many AASM models.
   def count_transitions!
     klass.class_eval do
-      aasm_with CustomAASMBase do
+      aasm :with_klass => CustomAASMBase do
         after_all_transitions :increment_transition_count
       end
     end
@@ -435,14 +435,14 @@ class CustomAASMBase < AASM::Base
 end
 ```
 
-When we declare our model that has an AASM state machine, we simply declare the AASM block with `aasm_with` to our own class.
+When we declare our model that has an AASM state machine, we simply declare the AASM block with a `:with` key to our own class.
 
 ```
 class SimpleCustomExample
   include AASM
 
   # Let's build an AASM state machine with our custom class.
-  aasm_with CustomAASMBase do
+  aasm :with_klass => CustomAASMBase do
     requires_guards!
     count_transitions!
 

--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -24,19 +24,8 @@ module AASM
       super
     end
 
-    # allows you to build an AASM model with application specific AASM::Base class.
-    def aasm_with(application_klass, *args, &block)
-      build_aasm(application_klass, *args, &block)
-    end
-
     # this is the entry point for all state and event definitions
     def aasm(*args, &block)
-      build_aasm(AASM::Base, *args, &block)
-    end
-
-    private
-
-    def build_aasm(aasm_klass, *args, &block)
       if args[0].is_a?(Symbol) || args[0].is_a?(String)
         # using custom name
         state_machine_name = args[0].to_sym
@@ -48,6 +37,10 @@ module AASM
       end
 
       AASM::StateMachine[self][state_machine_name] ||= AASM::StateMachine.new(state_machine_name)
+
+      # use a default despite the DSL configuration default.
+      # this is because configuration hasn't been setup for the AASM class but we are accessing a DSL option already for the class.
+      aasm_klass = options[:with_klass] || AASM::Base
 
       raise ArgumentError, "The class #{aasm_klass} must inherit from AASM::Base!" unless aasm_klass.ancestors.include?(AASM::Base)
 

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -28,6 +28,9 @@ module AASM
       # set to true to forbid direct assignment of aasm_state column (in ActiveRecord)
       configure :no_direct_assignment, false
 
+      # allow a AASM::Base sub-class to be used for state machine
+      configure :with_klass, AASM::Base
+
       configure :enum, nil
 
       # make sure to raise an error if no_direct_assignment is enabled

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -18,6 +18,9 @@ module AASM
     # forbid direct assignment in aasm_state column (in ActiveRecord)
     attr_accessor :no_direct_assignment
 
+    # allow a AASM::Base sub-class to be used for state machine
+    attr_accessor :with_klass
+
     attr_accessor :enum
   end
 end

--- a/spec/models/simple_custom_example.rb
+++ b/spec/models/simple_custom_example.rb
@@ -2,7 +2,7 @@ class CustomAASMBase < AASM::Base
   # A custom transiton that we want available across many AASM models.
   def count_transitions!
     klass.class_eval do
-      aasm_with CustomAASMBase do
+      aasm :with_klass => CustomAASMBase do
         after_all_transitions :increment_transition_count
       end
     end
@@ -35,7 +35,7 @@ class SimpleCustomExample
   include AASM
 
   # Let's build an AASM state machine with our custom class.
-  aasm_with CustomAASMBase do
+  aasm :with_klass => CustomAASMBase do
     requires_guards!
     count_transitions!
 

--- a/spec/models/simple_custom_example.rb
+++ b/spec/models/simple_custom_example.rb
@@ -1,0 +1,53 @@
+class CustomAASMBase < AASM::Base
+  # A custom transiton that we want available across many AASM models.
+  def count_transitions!
+    klass.class_eval do
+      aasm_with CustomAASMBase do
+        after_all_transitions :increment_transition_count
+      end
+    end
+  end
+
+  # A custom annotation that we want available across many AASM models.
+  def requires_guards!
+    klass.class_eval do
+      attr_reader :authorizable_called,
+        :transition_count,
+        :fillable_called
+
+      def authorizable?
+        @authorizable_called = true
+      end
+
+      def fillable?
+        @fillable_called = true
+      end
+
+      def increment_transition_count
+        @transition_count ||= 0
+        @transition_count += 1
+      end
+    end
+  end
+end
+
+class SimpleCustomExample
+  include AASM
+
+  # Let's build an AASM state machine with our custom class.
+  aasm_with CustomAASMBase do
+    requires_guards!
+    count_transitions!
+
+    state :initialised, :initial => true
+    state :filled_out
+    state :authorised
+
+    event :fill_out do
+      transitions :from => :initialised, :to => :filled_out, :guard => :fillable?
+    end
+    event :authorise do
+      transitions :from => :filled_out, :to => :authorised, :guard => :authorizable?
+    end
+  end
+end

--- a/spec/unit/simple_custom_example_spec.rb
+++ b/spec/unit/simple_custom_example_spec.rb
@@ -27,7 +27,7 @@ describe 'Custom AASM::Base' do
       Class.new do
         include AASM
 
-        aasm_with String do
+        aasm :with_klass => String do
         end
       end
     end

--- a/spec/unit/simple_custom_example_spec.rb
+++ b/spec/unit/simple_custom_example_spec.rb
@@ -24,7 +24,7 @@ describe 'Custom AASM::Base' do
 
   context 'when aasm_with invoked with non AASM::Base' do
     subject do
-      class SomeModel
+      Class.new do
         include AASM
 
         aasm_with String do

--- a/spec/unit/simple_custom_example_spec.rb
+++ b/spec/unit/simple_custom_example_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'state machine' do
+  let(:simple_custom) { SimpleCustomExample.new }
+
+  subject do
+    simple_custom.fill_out!
+    simple_custom.authorise
+  end
+
+  it 'has invoked authorizable?' do
+    expect { subject }.to change { simple_custom.authorizable_called }.from(nil).to(true)
+  end
+
+  it 'has invoked fillable?' do
+    expect { subject }.to change { simple_custom.fillable_called }.from(nil).to(true)
+  end
+
+  it 'has two transition counts' do
+    expect { subject }.to change { simple_custom.transition_count }.from(nil).to(2)
+  end
+end

--- a/spec/unit/simple_custom_example_spec.rb
+++ b/spec/unit/simple_custom_example_spec.rb
@@ -1,22 +1,39 @@
 require 'spec_helper'
 
-describe 'state machine' do
-  let(:simple_custom) { SimpleCustomExample.new }
+describe 'Custom AASM::Base' do
+  context 'when aasm_with invoked with SimpleCustomExample' do
+    let(:simple_custom) { SimpleCustomExample.new }
 
-  subject do
-    simple_custom.fill_out!
-    simple_custom.authorise
+    subject do
+      simple_custom.fill_out!
+      simple_custom.authorise
+    end
+
+    it 'has invoked authorizable?' do
+      expect { subject }.to change { simple_custom.authorizable_called }.from(nil).to(true)
+    end
+
+    it 'has invoked fillable?' do
+      expect { subject }.to change { simple_custom.fillable_called }.from(nil).to(true)
+    end
+
+    it 'has two transition counts' do
+      expect { subject }.to change { simple_custom.transition_count }.from(nil).to(2)
+    end
   end
 
-  it 'has invoked authorizable?' do
-    expect { subject }.to change { simple_custom.authorizable_called }.from(nil).to(true)
-  end
+  context 'when aasm_with invoked with non AASM::Base' do
+    subject do
+      class SomeModel
+        include AASM
 
-  it 'has invoked fillable?' do
-    expect { subject }.to change { simple_custom.fillable_called }.from(nil).to(true)
-  end
+        aasm_with String do
+        end
+      end
+    end
 
-  it 'has two transition counts' do
-    expect { subject }.to change { simple_custom.transition_count }.from(nil).to(2)
+    it 'should raise an ArgumentError' do
+      expect { subject }.to raise_error(ArgumentError, 'The class String must inherit from AASM::Base!')
+    end
   end
 end


### PR DESCRIPTION
This PR tries to make it a bit easier to DRY up logic across AASM models. It accomplishes this by letting developers extend `AASM::Base` and then declare their `aasm` blocks with the extended class.

I believe this will come in handy when we offer more global callbacks from #282. 

Currently, when we want to add functionality to AASM, we are re-opening the `AASM::Base` class to add the functionality we want to share across our many models. Here is an example.

```
module AASM
   class Base
    def use_our_modules!
      @klass.class_eval do
        include OurModule
      end
    end

    def foo!
      # do something foo-ey
    end

    def bar!
      # do something bar-ey
    end
end
```

Taking inspiration from a Rails 5 feature called `ApplicationRecord`, https://github.com/rails/rails/pull/22567, the goal of this PR is to let us represent that functionality in our own `AASM ApplicationRecord` and then have our AASM blocks use this, vs injecting ourselves into `AASM::Base`.