### PR TITLE
Delegate Event After_Commit Callbacks When Using ActiveRecord

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -107,11 +107,13 @@ module AASM
 
       klass.send :define_method, "#{name}!", ->(*args, &block) do
         aasm(:"#{aasm_name}").current_event = :"#{name}!"
+        aasm(:"#{aasm_name}").events_fired |= [[:"#{name}", *args]]
         aasm_fire_event(:"#{aasm_name}", :"#{name}", {:persist => true}, *args, &block)
       end
 
       klass.send :define_method, "#{name}", ->(*args, &block) do
         aasm(:"#{aasm_name}").current_event = :"#{name}"
+        aasm(:"#{aasm_name}").events_fired |= [[:"#{name}", *args]]
         aasm_fire_event(:"#{aasm_name}", :"#{name}", {:persist => false}, *args, &block)
       end
     end

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -1,11 +1,12 @@
 module AASM
   class InstanceBase
 
-    attr_accessor :from_state, :to_state, :current_event
+    attr_accessor :from_state, :to_state, :current_event, :events_fired
 
     def initialize(instance, name=:default) # instance of the class including AASM, name of the state machine
       @instance = instance
       @name = name
+      @events_fired = []
     end
 
     def current_state

--- a/spec/models/validator.rb
+++ b/spec/models/validator.rb
@@ -15,6 +15,7 @@ class Validator < ActiveRecord::Base
     after_all_transactions  :after_all_transactions
 
     state :sleeping, :initial => true
+    state :awake
     state :running
     state :failed, :after_enter => :fail
 
@@ -31,10 +32,15 @@ class Validator < ActiveRecord::Base
     end
 
     event :sleep do
-      after_commit do |name|
-        change_name_on_sleep name
-      end
-      transitions :to => :sleeping, :from => :running
+      after_commit { append_name!(' slept') }
+
+      transitions :to => :sleeping, :from => [:running, :awake]
+    end
+
+    event :wake do
+      after_commit { |description| append_name!(" awoke#{description}") }
+
+      transitions :to => :awake, :from => [:sleeping]
     end
 
     event :fail do
@@ -46,19 +52,19 @@ class Validator < ActiveRecord::Base
         @before_transaction_performed_on_fail = true
       end
 
-      transitions :to => :failed, :from => [:sleeping, :running]
+      transitions :to => :failed, :from => [:sleeping, :running, :awake]
     end
   end
 
   validates_presence_of :name
 
-  def change_name!
-    self.name = "name changed"
+  def append_name!(suffix)
+    self.name += suffix
     save!
   end
 
-  def change_name_on_sleep name
-    self.name = name
+  def change_name!
+    self.name = 'name changed'
     save!
   end
 
@@ -76,36 +82,44 @@ class Validator < ActiveRecord::Base
 end
 
 class MultipleValidator < ActiveRecord::Base
-
   include AASM
+
   aasm :left, :column => :status do
     state :sleeping, :initial => true
+    state :awake
     state :running
     state :failed, :after_enter => :fail
 
     event :run, :after_commit => :change_name! do
       transitions :to => :running, :from => :sleeping
     end
+
     event :sleep do
-      after_commit do |name|
-        change_name_on_sleep name
-      end
-      transitions :to => :sleeping, :from => :running
+      after_commit { append_name!(' slept') }
+
+      transitions :to => :sleeping, :from => [:running, :awake]
     end
+
+    event :wake do
+      after_commit { |description| append_name!(" awoke#{description}") }
+
+      transitions :to => :awake, :from => [:sleeping]
+    end
+
     event :fail do
-      transitions :to => :failed, :from => [:sleeping, :running]
+      transitions :to => :failed, :from => [:sleeping, :running, :awake]
     end
   end
 
   validates_presence_of :name
 
-  def change_name!
-    self.name = "name changed"
+  def append_name!(suffix)
+    self.name += suffix
     save!
   end
 
-  def change_name_on_sleep name
-    self.name = name
+  def change_name!
+    self.name = 'name changed'
     save!
   end
 

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -268,15 +268,15 @@ describe "instance methods" do
 end
 
 if ActiveRecord::VERSION::MAJOR < 4 && ActiveRecord::VERSION::MINOR < 2 # won't work with Rails >= 4.2
-describe "direct state column access" do
-  it "accepts false states" do
-    f = FalseState.create!
-    expect(f.aasm_state).to eql false
-    expect {
-      f.aasm.events.map(&:name)
-    }.to_not raise_error
+  describe "direct state column access" do
+    it "accepts false states" do
+      f = FalseState.create!
+      expect(f.aasm_state).to eql false
+      expect {
+        f.aasm.events.map(&:name)
+      }.to_not raise_error
+    end
   end
-end
 end
 
 describe 'subclasses' do
@@ -501,7 +501,7 @@ describe 'transitions with persistence' do
     end
 
     describe "after_commit callback" do
-      it "should fire :after_commit if transaction was successful" do
+      it "should fire state's :after_commit if transaction was successful" do
         validator = Validator.create(:name => 'name')
         expect(validator).to be_sleeping
 
@@ -509,22 +509,71 @@ describe 'transitions with persistence' do
         expect(validator).to be_running
         expect(validator.name).to eq("name changed")
 
-        validator.sleep!("sleeper")
+        validator.sleep!
         expect(validator).to be_sleeping
-        expect(validator.name).to eq("sleeper")
+        expect(validator.name).to eq("name changed slept")
       end
 
-      it "should not fire :after_commit if transaction failed" do
+      it "should not fire state's :after_commit if transaction failed" do
         validator = Validator.create(:name => 'name')
+
         expect { validator.fail! }.to raise_error(StandardError, 'failed on purpose')
         expect(validator.name).to eq("name")
       end
 
-      it "should not fire if not saving" do
+      it "should fire state's :after_commit if manually persisted" do
         validator = Validator.create(:name => 'name')
         expect(validator).to be_sleeping
+
+        validator.run
+        validator.save!
+        expect(validator).to be_running
+        expect(validator.name).to eq("name changed")
+      end
+
+      it "should not immediately fire state's :after_commit if not saving" do
+        validator = Validator.create(:name => 'name')
+        expect(validator).to be_sleeping
+
         validator.run
         expect(validator).to be_running
+        expect(validator.name).to eq("name")
+      end
+
+      it "should fire all events' :after_commit hooks in if saving" do
+        validator = Validator.create(:name => 'name')
+        expect(validator).to be_sleeping
+
+        validator.wake!(" feeling grumpy")
+        expect(validator).to be_awake
+
+        validator.sleep!
+        expect(validator).to be_sleeping
+        expect(validator.name).to eq("name awoke feeling grumpy slept")
+      end
+
+      it "should fire all events' :after_commit hooks in order if manually persisted" do
+        validator = Validator.create(:name => 'name')
+        expect(validator).to be_sleeping
+
+        validator.wake(" feeling grumpy")
+        expect(validator).to be_awake
+
+        validator.sleep
+        validator.save!
+        expect(validator).to be_sleeping
+        expect(validator.name).to eq("name awoke feeling grumpy slept")
+      end
+
+      it "should not immediately fire any events' :after_commit hooks if not saving" do
+        validator = Validator.create(:name => 'name')
+        expect(validator).to be_sleeping
+
+        validator.wake
+        expect(validator).to be_awake
+
+        validator.sleep
+        expect(validator).to be_sleeping
         expect(validator.name).to eq("name")
       end
     end


### PR DESCRIPTION
This PR reimplements @hjdivad's [patch](https://github.com/aasm/aasm/pull/170) delegating event `after_commit` callbacks 
when using ActiveRecord.  This allows the `after_commit` callbacks to be fired 
both when the record is persisted immediately (eg., via `#event!` methods) as  well 
as when the record is persisted manually (eg., via the `#event` method, followed by 
a `#save`.)  It also preserves the order of `after_commit` callbacks in the case of 
multiple state transitions.

This (patched) behavior is  more  consistent with how ActiveRecord handles 
`after_commit` callbacks.