### PR TITLE
Document return value for auto-saved state transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,11 +423,13 @@ job.run   # not saved
 job.run!  # saved
 ```
 
-Saving includes running all validations on the `Job` class. If you want make sure
-the state gets saved without running validations (and thereby maybe persisting an
-invalid object state), simply tell AASM to skip the validations. Be aware that
-when skipping validations, only the state column will be updated in the database
-(just like ActiveRecord `change_column` is working).
+Saving includes running all validations on the `Job` class, and returns `true` if
+successful or `false` if errors occur. Exceptions are not raised.
+
+If you want make sure the state gets saved without running validations (and
+thereby maybe persisting aninvalid object state), simply tell AASM to skip the
+validations. Be aware that when skipping validations, only the state column will
+be updated in the database (just like ActiveRecord `change_column` is working).
 
 ```ruby
 class Job < ActiveRecord::Base


### PR DESCRIPTION
My team just ran into a bug that took a long time to track down where
an auto-saved state transition method unexpectedly swallowed
exceptions. Some documentation on the behavior would have saved a lot
of searching. :)