### PR TITLE
Fixes incorrect permitted states

### DIFF
--- a/spec/models/multi_transitioner.rb
+++ b/spec/models/multi_transitioner.rb
@@ -1,0 +1,24 @@
+class MultiTransitioner
+  include AASM
+
+  attr_accessor :can_run
+
+  def initialize
+    @can_run = false
+  end
+
+  aasm do
+    state :sleeping, :initial => true
+    state :running
+    state :dancing
+
+    event :start do
+      transitions :from => :sleeping, :to => :running, guard: :runnable?
+      transitions :from => :sleeping, :to => :dancing
+    end
+  end
+
+  def runnable?
+    @can_run
+  end
+end

--- a/spec/unit/inspection_spec.rb
+++ b/spec/unit/inspection_spec.rb
@@ -17,6 +17,7 @@ describe 'inspection for common cases' do
   context "instance level inspection" do
     let(:foo) { Foo.new }
     let(:two) { FooTwo.new }
+    let(:multi) { MultiTransitioner.new }
 
     it "delivers all states" do
       states = foo.aasm.states
@@ -37,11 +38,13 @@ describe 'inspection for common cases' do
       states = two.aasm.states
       expect(states).to include(:open)
       expect(states).to include(:closed)
+      expect(states).to include(:final)
       expect(states).to include(:foo)
 
       states = two.aasm.states(:permitted => true)
       expect(states).to include(:closed)
       expect(states).not_to include(:open)
+      expect(states).not_to include(:final)
 
       two.close
       expect(two.aasm.states(:permitted => true)).to be_empty
@@ -53,6 +56,18 @@ describe 'inspection for common cases' do
       expect(events).to include(:null)
       foo.close
       expect(foo.aasm.events).to be_empty
+    end
+
+    it "delivers permitted states when multiple transitions are defined" do
+      multi.can_run = false
+      states = multi.aasm.states(:permitted => true)
+      expect(states).to_not include(:running)
+      expect(states).to include(:dancing)
+
+      multi.can_run = true
+      states = multi.aasm.states(:permitted => true)
+      expect(states).to include(:running)
+      expect(states).to_not include(:dancing)
     end
   end
 


### PR DESCRIPTION
Permitted states now returns the correct states when an event has more than one transition, and if a transition uses a guard. This is similar to #150.

--

I was trying to get a list of permissible states, but my state machine has an event with multiple transitions, where one transition is guarded. Here's a simplified example that was failing prior to this PR:

```ruby
require 'aasm'

class Foo
  include AASM

  attr_accessor :can_run

  def initialize
    @can_run = false
  end

  aasm do
    state :sleeping, :initial => true
    state :running
    state :dancing

    event :start do
      transitions :from => :sleeping, :to => :running, guard: :runnable?
      transitions :from => :sleeping, :to => :dancing
    end
  end

  def runnable?
    @can_run
  end
end

foo = Foo.new
foo.can_run = false
foo.aasm.states(:permitted => true).map(&:name)

# Actual
=> [:running]

# Expected
=> [:dancing]
```

Following the behavior mentioned in [Transitions](https://github.com/aasm/aasm#transitions),

> In the event of having multiple transitions for an event, the first transition that successfully completes will stop other transitions in the same event from being processed.

`states(permitted: true)` will only return the first state that would be transitioned to, respecting any guards set on the transitions.

All existing specs pass, and I added a spec for the edge case I found.

Let me know if I missed anything!