### PR TITLE
Rspec custom matcher: `on_event` with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,8 @@ expect(job).to allow_event :run
 expect(job).to_not allow_event :clean
 expect(job).to allow_transition_to(:running)
 expect(job).to_not allow_transition_to(:cleaning)
+# on_event also accept arguments
+expect(job).to transition_from(:sleeping).to(:running).on_event(:run, :deframengation)
 
 # classes with multiple state machine
 multiple = SimpleMultipleExample.new

--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ expect(job).to_not allow_event :clean
 expect(job).to allow_transition_to(:running)
 expect(job).to_not allow_transition_to(:cleaning)
 # on_event also accept arguments
-expect(job).to transition_from(:sleeping).to(:running).on_event(:run, :deframengation)
+expect(job).to transition_from(:sleeping).to(:running).on_event(:run, :defragmentation)
 
 # classes with multiple state machine
 multiple = SimpleMultipleExample.new

--- a/lib/aasm/rspec/transition_from.rb
+++ b/lib/aasm/rspec/transition_from.rb
@@ -2,8 +2,7 @@ RSpec::Matchers.define :transition_from do |from_state|
   match do |obj|
     @state_machine_name ||= :default
     obj.aasm(@state_machine_name).current_state = from_state.to_sym
-    # expect(obj).to receive(:broadcast_event).with(@event.to_s, obj, from_state, @to_state)
-    obj.send(@event) && obj.aasm(@state_machine_name).current_state == @to_state.to_sym
+    obj.send(@event, *@args) && obj.aasm(@state_machine_name).current_state == @to_state.to_sym
   end
 
   chain :on do |state_machine_name|
@@ -14,12 +13,13 @@ RSpec::Matchers.define :transition_from do |from_state|
     @to_state = state
   end
 
-  chain :on_event do |event|
+  chain :on_event do |event, *args|
     @event = event
+    @args = args
   end
 
   description do
-    "transition state to :#{@to_state} from :#{expected} on event :#{@event} (on :#{@state_machine_name})"
+    "transition state to :#{@to_state} from :#{expected} on event :#{@event}, with params: #{@args} (on :#{@state_machine_name})"
   end
 
   failure_message do |obj|


### PR DESCRIPTION
- Give the possibility to pass arguments to the `on_event` function of the Rspec custom matcher.
- Add a example to the README

