### PR TITLE
RubyMotion support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,11 @@ Job.aasm.states_for_select
 ```
 
 
+### RubyMotion support
+
+To use AASM with a RubyMotion project, use it with the [motion-bundler](https://github.com/archan937/motion-bundler) gem.
+
+
 ### Testing
 
 AASM provides some matchers for [RSpec](http://rspec.info): `transition_from`, `have_state`, `allow_event` and `allow_transition_to`. Add `require 'aasm/rspec'` to your `spec_helper.rb` file and use them like this
@@ -815,7 +820,7 @@ After installing Aasm you can run generator:
 ```sh
 % rails generate aasm NAME [COLUMN_NAME]
 ```
-Replace NAME with the Model name, COLUMN_NAME is optional(default is 'aasm_state'). 
+Replace NAME with the Model name, COLUMN_NAME is optional(default is 'aasm_state').
 This will create a model (if one does not exist) and configure it with aasm block.
 For Active record orm a migration file is added to add aasm state column to table.
 

--- a/lib/aasm.rb
+++ b/lib/aasm.rb
@@ -12,4 +12,5 @@ require 'aasm/core/state'
 require 'aasm/localizer'
 require 'aasm/state_machine'
 require 'aasm/persistence'
+require 'aasm/persistence/plain_persistence' # RubyMotion support
 require 'aasm/aasm'

--- a/lib/aasm/persistence.rb
+++ b/lib/aasm/persistence.rb
@@ -23,7 +23,7 @@ module AASM
 
       def include_persistence(base, type)
         require File.join(File.dirname(__FILE__), 'persistence', "#{type}_persistence")
-        base.send(:include, constantize("AASM::Persistence::#{capitalize(type)}Persistence"))
+        base.send(:include, constantize("#{capitalize(type)}Persistence"))
       end
 
       def capitalize(string_or_symbol)
@@ -31,7 +31,7 @@ module AASM
       end
 
       def constantize(string)
-        instance_eval(string)
+        AASM::Persistence.const_get(string)
       end
 
     end # class << self


### PR DESCRIPTION
Hi,

I wanted to be able to use AASM in my new RubyMotion project.
I fooled around a little to see if it was possible and by the time I was done with it I realised all specs were still valid. So I was wondering if you would be interested to merge that support back on your side ?

Basically all I had to do is to remove all string-based eval-like code and replace them with a good old define_method. That and 2 minor changes on the persistence 'constantize' method and the list of required files by the gem. That's all.

So there it is !