### PR TITLE
Add option to use Class that responds to call for after transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ class Job
       end
 
       transitions :from => :sleeping, :to => :running, :after => Proc.new {|*args| set_process(*args) }
+      transitions :from => :running, :to => :finished, :after => LogRunTime
     end
 
     event :sleep do
@@ -136,11 +137,33 @@ class Job
   end
 
 end
+
+class LogRunTime
+  def call
+    log "Job was running for X seconds"
+  end
+end
 ```
 
 In this case `do_something` is called before actually entering the state `sleeping`,
 while `notify_somebody` is called after the transition `run` (from `sleeping` to `running`)
 is finished.
+
+AASM will also initialize `LogRunTime` and run the `call` method for you after the transition from `runnung` to `finished` in the example above. You can pass arguments to the class by defining an initialize method on it, like this:
+
+```
+class LogRunTime
+  # optional args parameter can be omitted, but if you define initialize
+  # you must accept the model instance as the first parameter to it.
+  def initialize(job, args = {})
+    @job = job
+  end
+  
+  def call
+    log "Job was running for #{@job.run_time} seconds"
+  end
+end
+```
 
 Here you can see a list of all possible callbacks, together with their order of calling:
 

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -61,6 +61,18 @@ module AASM::Core
         result = (code.parameters.size == 0 ? record.instance_exec(&code) : record.instance_exec(*args, &code))
         failures << code.source_location.join('#') unless result
         result
+      when Class
+        arity = code.instance_method(:initialize).arity
+        if arity == 0
+          instance = code.new
+        elsif arity == 1
+          instance = code.new(record)
+        else
+          instance = code.new(record, *args)
+        end
+        result = instance.call
+        failures << instance.method(:call).source_location.join('#') unless result
+        result
       when Array
         if options[:guard]
           # invoke guard callbacks


### PR DESCRIPTION
Hi,

After transitions can sometimes become large or complex enough to warrant their own classes to provide a separation of concerns or to simply organize code in a cleaner way.  A common pattern in ruby/rails projects is to delegate this work to a class that responds to a `call` method.

This PR will allow AASM defined state machines to use the `after` transition option by simply passing the name of a class that responds to `call`. It also allows you to pass in arguments to the after transition, similar to the other `after` options. In this case, the arguments will automatically be provided to the `initialize` method of the class you define.

Example:

```
class Job < ActiveRecord::Base
  include AASM

  aasm do
    state :ready
    state :completed

    event :complete do
      transitions from: :ready, to: :completed, after: CompleteEvent
    end
  end
end

class CompleteEvent
  def initialize(record, notes)
    @record = record  # provides access to the underlying Job instance
    @notes = notes    # contains "Notes about the work that was completed" in this example
  end

  def call
    # Notify the customer that the job is completed,
    # record the total time it took to complete the job
    # or any other work that needs to happen.
  end
end

job.complete!("Notes about the work that was completed")
```

Please let me know your thoughts.

Thanks for maintaining such an excellent project!