### PR TITLE
Adding a warning regarding RubyMotion support and KVO

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,9 @@ Job.aasm.states_for_select
 
 To use AASM with a RubyMotion project, use it with the [motion-bundler](https://github.com/archan937/motion-bundler) gem.
 
+Warning: Due to the way key-value observation (KVO) works in iOS, 
+you currently CANNOT use AASM with an object you are observing. (Yes.. that's pretty sad).
+
 
 ### Testing
 


### PR DESCRIPTION
I just found an issue with the use of KVO (key-value observer) in RubyMotion.

Since KVOs change the class of the object, it completely mess with the way you store and retrieve the different state machines (the inherited method does not seem to be called by the KVO), as you use the class as keys to the storing hash.

I may have an idea on how to fix that, but i may require some time before I crack it so I thought I'd put a warning in the meantime so nobody lose their time trying to find the origin of the issue.

I'll get back to you once I've got some more details on how I can fix that. (probably through the options though)