### PR TITLE
[RubyMotion support] Fixing some issues with Proc based guardians and callbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,8 +754,12 @@ Job.aasm.states_for_select
 
 To use AASM with a RubyMotion project, use it with the [motion-bundler](https://github.com/archan937/motion-bundler) gem.
 
-Warning: Due to the way key-value observation (KVO) works in iOS, 
+Warnings:
+- Due to the way key-value observation (KVO) works in iOS,
 you currently CANNOT use AASM with an object you are observing. (Yes.. that's pretty sad).
+- Due to RubyMotion Proc's lack of 'source_location' method, it may be harder
+to find out the origin of a "cannot transition from" error. I would recommend using
+the 'instance method symbol / string' way whenever possible when defining guardians and callbacks.
 
 
 ### Testing

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -53,12 +53,22 @@ module AASM::Core
 
       case code
       when Symbol, String
-        arity = record.__send__(:method, code.to_sym).arity
-        result = (arity == 0 ? record.__send__(code) : result = record.__send__(code, *args))
+        result = (record.__send__(:method, code.to_sym).arity == 0 ? record.__send__(code) : result = record.__send__(code, *args))
         failures << code unless result
         result
       when Proc
-        result = (code.parameters.size == 0 ? record.instance_exec(&code) : record.instance_exec(*args, &code))
+        if code.respond_to?(:parameters)
+          # In Ruby's Proc, the 'arity' method is not a good condidate to know if
+          # we should pass the arguments or not, since its does return 0 even in
+          # presence of optional parameters.
+          result = (code.parameters.size == 0 ? record.instance_exec(&code) : record.instance_exec(*args, &code))
+        else
+          # In RubyMotion's Proc, the parameter method does not exists, however its
+          # 'arity' method works just like the one from Method, only returning 0 when
+          # there is no parameters whatsoever, optional or not.
+          result = (code.arity == 0 ? record.instance_exec(&code) : record.instance_exec(*args, &code))
+        end
+
         failures << code.source_location.join('#') unless result
         result
       when Array

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -62,14 +62,18 @@ module AASM::Core
           # we should pass the arguments or not, since its does return 0 even in
           # presence of optional parameters.
           result = (code.parameters.size == 0 ? record.instance_exec(&code) : record.instance_exec(*args, &code))
+
+          failures << code.source_location.join('#') unless result
         else
-          # In RubyMotion's Proc, the parameter method does not exists, however its
+          # In RubyMotion's Proc, the 'parameter' method does not exists, however its
           # 'arity' method works just like the one from Method, only returning 0 when
           # there is no parameters whatsoever, optional or not.
           result = (code.arity == 0 ? record.instance_exec(&code) : record.instance_exec(*args, &code))
+
+          # Sadly, RubyMotion's Proc does not define the method 'source_location' either.
+          failures << code unless result
         end
 
-        failures << code.source_location.join('#') unless result
         result
       when Array
         if options[:guard]


### PR DESCRIPTION
Spotted an issue due to RubyMotion's Proc implementation.

Proc does not have the method 'parameters' nor 'source_location'.
This was going to be a pain in my ass until I discovered that Proc's 'arity' method had a different behavior in Ruby and RubyMotion.. at my advantage !
I had to sacrify some debugging 'hints' for us RubyMotion developers to achieve the fix, but nothing too hard.

