### PR TITLE
Move creation of scopes to persistence adapaters

### DIFF
--- a/lib/aasm/persistence/mongo_mapper_persistence.rb
+++ b/lib/aasm/persistence/mongo_mapper_persistence.rb
@@ -33,11 +33,19 @@ module AASM
       def self.included(base)
         base.send(:include, AASM::Persistence::Base)
         base.send(:include, AASM::Persistence::MongoMapperPersistence::InstanceMethods)
+        base.extend AASM::Persistence::MongoMapperPersistence::ClassMethods
 
         base.before_create :aasm_ensure_initial_state
 
         # ensure state is in the list of states
         base.validate :aasm_validate_states
+      end
+
+      module ClassMethods
+        def aasm_create_scope(state_machine_name, scope_name)
+          conditions = { aasm(state_machine_name).attribute_name.to_sym => scope_name.to_s }
+          scope(scope_name, lambda { where(conditions) })
+        end
       end
 
       module InstanceMethods

--- a/lib/aasm/persistence/mongoid_persistence.rb
+++ b/lib/aasm/persistence/mongoid_persistence.rb
@@ -33,8 +33,21 @@ module AASM
       def self.included(base)
         base.send(:include, AASM::Persistence::Base)
         base.send(:include, AASM::Persistence::MongoidPersistence::InstanceMethods)
+        base.extend AASM::Persistence::MongoidPersistence::ClassMethods
 
         base.after_initialize :aasm_ensure_initial_state
+      end
+
+      module ClassMethods
+        def aasm_create_scope(state_machine_name, scope_name)
+          scope_options = lambda {
+            send(
+              :where,
+              { aasm(state_machine_name).attribute_name.to_sym => scope_name.to_s }
+            )
+          }
+          send(:scope, scope_name, scope_options)
+        end
       end
 
       module InstanceMethods


### PR DESCRIPTION
I have a large Rails application and the other day I was profiling boot time. I noticed that AASM contributes to 5% of the boot time (using the StackProf gem):


```
==================================
  Mode: wall(1000)
  Samples: 13519 (12.03% miss rate)
  GC: 1422 (10.52%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     20752 (153.5%)        2655  (19.6%)     block in ActiveSupport::Dependencies::Loadable#require
      1041   (7.7%)         947   (7.0%)     block in Module#delegate
       901   (6.7%)         901   (6.7%)     block in ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
       551   (4.1%)         551   (4.1%)     block in AASM::Base#ancestors_include?     <------------------------------------------ !!!
       206   (1.5%)         206   (1.5%)     #<Module:0x007ff2ca7b60c8>.mechanism
       160   (1.2%)         160   (1.2%)     block in #<Module:0x007ff2ca58f7b8>.load_persistence     <------------------------------------------ !!!
       256   (1.9%)         140   (1.0%)     Bundler::Molinillo::DependencyGraph#add_vertex
       116   (0.9%)         116   (0.9%)     Bundler::Molinillo::DependencyGraph::Vertex#initialize
       104   (0.8%)         101   (0.7%)     AASM::Base#state
        93   (0.7%)          93   (0.7%)     block (4 levels) in Class#class_attribute
        91   (0.7%)          91   (0.7%)     Module#remove_possible_method
      2342  (17.3%)          84   (0.6%)     block (2 levels) in Bundler::Runtime#require
        95   (0.7%)          77   (0.6%)     Set#include?
       384   (2.8%)          76   (0.6%)     block in Bundler::Molinillo::DependencyGraph#initialize_copy
        71   (0.5%)          71   (0.5%)     block (2 levels) in #<Module:0x007ff2ca745008>.read_general_category_per_cp
        68   (0.5%)          68   (0.5%)     Bundler::Molinillo::DependencyGraph#add_edge_no_circular
      1298   (9.6%)          66   (0.5%)     ActionDispatch::Joq1rney::Visitors::Each#visit
        76   (0.6%)          64   (0.5%)     ActiveSupport::Inflector#underscore
        92   (0.7%)          60   (0.4%)     Set#add
        58   (0.4%)          58   (0.4%)     Psych::Nodes::Scalar#initialize
        61   (0.5%)          57   (0.4%)     AASM::Base#event
        57   (0.4%)          57   (0.4%)     Gem::Version#prerelease?
        55   (0.4%)          55   (0.4%)     block in ActiveSupport::Inflector#apply_inflections
      1874  (13.9%)          51   (0.4%)     Kernel#require
        50   (0.4%)          50   (0.4%)     ActionDispatch::Journey::Nodes::Node#initialize
       509   (3.8%)          48   (0.4%)     ActionDispatch::Routing::Mapper::Scope#[]
        47   (0.3%)          47   (0.3%)     Gem::BasicSpecification#loaded_from=
        46   (0.3%)          46   (0.3%)     Gem::Version#version
       114   (0.8%)          45   (0.3%)     <class:Base>
       107   (0.8%)          44   (0.3%)     Gem::Version#<=>
```

`AASM::Base#ancestors_include?` takes 4.1% and `AASM::Persistence.load_persistence` 1.2%. 


This PR moves the ORM-specific code to create the scopes to the persistence adapters and includes the "create_scope" method there. Instead of calling `AASM::Base#ancestors_include?` (`@klass.ancestors.map { |klass| klass.to_s }` turns out be be expensive), it is now possible to simply check if the class responds to that method.

I find it also nice that all adapter-specific code is in one place.


StackProf results:

```
==================================
  Mode: wall(1000)
  Samples: 12893 (12.31% miss rate)
  GC: 1384 (10.73%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     19479 (151.1%)        2637  (20.5%)     block in ActiveSupport::Dependencies::Loadable#require
      1057   (8.2%)         959   (7.4%)     block in Module#delegate
       958   (7.4%)         958   (7.4%)     block in ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
       195   (1.5%)         195   (1.5%)     #<Module:0x007f83dc349d58>.mechanism
       155   (1.2%)         155   (1.2%)     block in #<Module:0x007f83dc6a92c8>.load_persistence
       273   (2.1%)         146   (1.1%)     Bundler::Molinillo::DependencyGraph#add_vertex
       127   (1.0%)         127   (1.0%)     Bundler::Molinillo::DependencyGraph::Vertex#initialize
       114   (0.9%)         114   (0.9%)     block (4 levels) in Class#class_attribute
       102   (0.8%)         102   (0.8%)     Module#remove_possible_method
       118   (0.9%)          92   (0.7%)     Set#include?
        74   (0.6%)          74   (0.6%)     AASM::Base#state
      2324  (18.0%)          74   (0.6%)     block (2 levels) in Bundler::Runtime#require
       394   (3.1%)          73   (0.6%)     block in Bundler::Molinillo::DependencyGraph#initialize_copy
      1394  (10.8%)          73   (0.6%)     ActionDispatch::Journey::Visitors::Each#visit
        80   (0.6%)          71   (0.6%)     ActiveSupport::Inflector#underscore
        71   (0.6%)          71   (0.6%)     block (2 levels) in #<Module:0x007f83db20cb80>.read_general_category_per_cp
        57   (0.4%)          57   (0.4%)     Psych::Nodes::Scalar#initialize
        87   (0.7%)          56   (0.4%)     Set#add
        56   (0.4%)          56   (0.4%)     Bundler::Molinillo::DependencyGraph#add_edge_no_circular
        55   (0.4%)          55   (0.4%)     ActiveRecord::Attributes::ClassMethods#clear_caches_calculated_from_columns
       119   (0.9%)          54   (0.4%)     Gem::Version#<=>
        56   (0.4%)          52   (0.4%)     AASM::Base#event
      1913  (14.8%)          52   (0.4%)     Kernel#require
        52   (0.4%)          52   (0.4%)     Gem::Version#version
        51   (0.4%)          51   (0.4%)     block in ActiveSupport::Inflector#apply_inflections
        49   (0.4%)          49   (0.4%)     Gem::Version#prerelease?
        48   (0.4%)          48   (0.4%)     ActionDispatch::Journey::Nodes::Node#initialize
       108   (0.8%)          45   (0.3%)     <class:Base>
       127   (1.0%)          44   (0.3%)     block (3 levels) in Class#class_attribute
        44   (0.3%)          44   (0.3%)     Gem::BasicSpecification#loaded_from=
```

Only the `load_persistence` is left, which uses `@klass.ancestors.map` as well (but only once per class). This could be improved, too, but that's maybe something for another PR. For now I could simply get rid of that by the patch (using ActiveRecord):

```Ruby
module AASM
  module Persistence
    class << self
      def load_persistence(base)
        if base < ActiveRecord::Base
          include_persistence base, :active_record
        end
      end
    end
  end
end
```
