### PR TITLE
Fix warning when overriding an exsiting method

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ simple.aasm(:work).current
 
 _AASM_ doesn't prohibit to define the same event in more than one state machine. The
 latest definition "wins" and overrides previous definitions. Nonetheless, a warning is issued:
-`SimpleMultipleExample: The aasm event name run is already used!`.
+`SimpleMultipleExample: overriding method 'run'!`.
 
 All _AASM_ class- and instance-level `aasm` methods accept a state machine selector.
 So, for example, to use inspection on a class level, you have to use

--- a/spec/unit/override_warning_spec.rb
+++ b/spec/unit/override_warning_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'warns when overrides a method' do
+  module Clumsy
+    def self.included base
+      base.send :include, AASM
+
+      base.aasm do
+        state :valid
+        event(:save) { }
+      end
+    end
+  end
+
+  describe 'state' do
+    class Base
+      def valid?; end
+    end
+    it do
+      expect { Base.send :include, Clumsy }.
+        to output(/Base: overriding method 'valid\?'!/).to_stderr
+    end
+  end
+
+  describe 'event' do
+    context 'may?' do
+      class Base
+        def may_save?; end
+        def save!; end
+        def save; end
+      end
+      let(:klass) { Base }
+      it do
+        expect { Base.send :include, Clumsy }.
+          to output(/Base: overriding method 'may_save\?'!/).to_stderr
+        expect { Base.send :include, Clumsy }.
+          to output(/Base: overriding method 'save!'!/).to_stderr
+        expect { Base.send :include, Clumsy }.
+          to output(/Base: overriding method 'save'!/).to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
When overriding an existing method in base class (be it event redefinition by another state machine for same class or method originally defined in class itself), there should be a warning message.

The meat: klass.instance_methods.include?(method_name*.to_sym*)
Test added. Some rearrangement.

Fixes #335