### PR TITLE
Suppress warnings when using ActiveRecord enums feature

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -193,7 +193,7 @@ module AASM
     end
 
     def safely_define_method(klass, method_name, method_definition)
-      if klass.instance_methods.include?(method_name.to_sym)
+      if !@options[:enum] && klass.instance_methods.include?(method_name.to_sym)
         warn "#{klass.name}: overriding method '#{method_name}'!"
       end
 


### PR DESCRIPTION
ActiveRecord enums feature defines the `state_name?` method, 
therefore `safely_define_method` warns `overriding method` whenever I use aasm with enums.
AASM works as expected, but it is little annoying for me.

So, this PR suppresses those warnings when using enums.
How is this?