### PR TITLE
Silence method override warning when it's an enum

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -193,8 +193,8 @@ module AASM
     end
 
     def safely_define_method(klass, method_name, method_definition)
-      # Warn if method already exists and it did not originate from an enum
-      if klass.instance_methods.include?(method_name.to_sym) &&
+      # Warn if method exists and it did not originate from an enum
+      if klass.method_defined?(method_name) &&
          ! ( @state_machine.config.enum &&
              klass.respond_to?(:defined_enums) &&
              klass.defined_enums.values.any?{ |methods|

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -193,7 +193,13 @@ module AASM
     end
 
     def safely_define_method(klass, method_name, method_definition)
-      if !@options[:enum] && klass.instance_methods.include?(method_name.to_sym)
+      # Warn if method already exists and it did not originate from an enum
+      if klass.instance_methods.include?(method_name.to_sym) &&
+         ! ( @state_machine.config.enum &&
+             klass.respond_to?(:defined_enums) &&
+             klass.defined_enums.values.any?{ |methods|
+                 methods.keys{| enum | enum + '?' == method_name }
+             })
         warn "#{klass.name}: overriding method '#{method_name}'!"
       end
 

--- a/spec/unit/override_warning_spec.rb
+++ b/spec/unit/override_warning_spec.rb
@@ -12,6 +12,21 @@ describe 'warns when overrides a method' do
     end
   end
 
+  module WithEnumBase
+    def self.included base
+      base.send :include, AASM
+      base.instance_eval do
+        def defined_enums
+          { 'state' => { 'valid' => 0, 'invalid' => 1 } }
+        end
+      end
+      base.aasm enum: true do
+        state :valid
+        event(:save) { }
+      end
+    end
+  end
+
   describe 'state' do
     class Base
       def valid?; end
@@ -19,6 +34,16 @@ describe 'warns when overrides a method' do
     it do
       expect { Base.send :include, Clumsy }.
         to output(/Base: overriding method 'valid\?'!/).to_stderr
+    end
+  end
+
+  describe 'enum' do
+    class EnumBase
+      def valid?; end
+    end
+    it "dosn't warn when overriding an enum" do
+      expect { EnumBase.send :include, WithEnumBase }.
+        not_to output(/EnumBase: overriding method 'valid\?'!/).to_stderr
     end
   end
 
@@ -40,4 +65,5 @@ describe 'warns when overrides a method' do
       end
     end
   end
+
 end


### PR DESCRIPTION
This silences the `overriding method xxxx!` warning that's emitted when the overridden method came from an enum. 

I didn't notice #346 when I created this, but but this may be a better approach since it actually checks for defined enums using `defined_enums` (if present)