### PR TITLE
Support :permitted => false for states and events

### DIFF
--- a/spec/unit/inspection_spec.rb
+++ b/spec/unit/inspection_spec.rb
@@ -25,10 +25,15 @@ describe 'inspection for common cases' do
       expect(states).to include(:closed)
       expect(states).to include(:final)
 
-      states = foo.aasm.states(:permitted => true)
-      expect(states).to include(:closed)
-      expect(states).not_to include(:open)
-      expect(states).not_to include(:final)
+      permitted_states = foo.aasm.states(:permitted => true)
+      expect(permitted_states).to include(:closed)
+      expect(permitted_states).not_to include(:open)
+      expect(permitted_states).not_to include(:final)
+
+      blocked_states = foo.aasm.states(:permitted => false)
+      expect(blocked_states).to include(:closed)
+      expect(blocked_states).not_to include(:open)
+      expect(blocked_states).to include(:final)
 
       foo.close
       expect(foo.aasm.states(:permitted => true)).to be_empty
@@ -122,5 +127,18 @@ describe 'permitted events' do
   it 'should not include events in the reject option' do
     expect(foo.aasm.events(:permitted => true, reject: :close)).not_to include(:close)
     expect(foo.aasm.events(:permitted => true, reject: [:close])).not_to include(:close)
+  end
+end
+
+describe 'not permitted events' do
+  let(:foo) {Foo.new}
+
+  it 'work' do
+    expect(foo.aasm.events(:permitted => false)).to include(:null)
+    expect(foo.aasm.events(:permitted => false)).not_to include(:close)
+  end
+
+  it 'should not include events in the reject option' do
+    expect(foo.aasm.events(:permitted => false, reject: :null)).to eq([])
   end
 end


### PR DESCRIPTION
Given the following Job class
```ruby
class Job
  include AASM

  aasm do
    state :sleeping, :initial => true
    state :running, :cleaning

    event :run do
      transitions :from => :sleeping, :to => :running
    end

    event :clean do
      transitions :from => :running, :to => :cleaning, :guard => :cleaning_needed?
    end

    event :sleep do
      transitions :from => [:running, :cleaning], :to => :sleeping
    end
  end
  
  def cleaning_needed?
    false
  end
end
```

and a `job` object currently in `:running` state
```ruby  
job.aasm.events(:permitted => false) #=> [:clean, :sleep]
# instead of the expected [:clean]

job.aasm.states(:permitted => false) #=> [:cleaning, :sleeping]
# instead of the expected [:cleaning]
```
This bug was caused by an ambiguous condition on `if options[:permitted]` which defaults to the full list of possible events/states if `:permitted => false`.