### PR TITLE
Implement whiny persistence so that `transition!` will raise by default, mirroring ActiveRecord's behavior.

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -23,6 +23,9 @@ module AASM
       # don't store any new state if the model is invalid (in ActiveRecord)
       configure :skip_validation_on_save, false
 
+      # raise if the model is invalid (in ActiveRecord)
+      configure :whiny_persistence, true
+
       # use requires_new for nested transactions (in ActiveRecord)
       configure :requires_new_transaction, true
 

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -24,7 +24,7 @@ module AASM
       configure :skip_validation_on_save, false
 
       # raise if the model is invalid (in ActiveRecord)
-      configure :whiny_persistence, true
+      configure :whiny_persistence, false
 
       # use requires_new for nested transactions (in ActiveRecord)
       configure :requires_new_transaction, true

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -9,7 +9,10 @@ module AASM
     # for all persistence layers: create named scopes for each state
     attr_accessor :create_scopes
 
-    # for ActiveRecord: don't store any new state if the model is invalid
+    # for ActiveRecord: when the model is invalid, true -> raise, false -> return false
+    attr_accessor :whiny_persistence
+
+    # for ActiveRecord: store the new state even if the model is invalid and return true
     attr_accessor :skip_validation_on_save
 
     # for ActiveRecord: use requires_new for nested transactions?

--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -76,7 +76,12 @@ module AASM
             self.save
           end
 
-          success ? true : aasm_rollback(name, old_value)
+          unless success
+            aasm_rollback(name, old_value)
+            raise ActiveRecord::RecordInvalid.new(self) if aasm_whiny_persistence(name)
+          end
+
+          success
         end
 
         # Writes <tt>state</tt> to the state column, but does not persist it to the database
@@ -128,6 +133,10 @@ module AASM
 
         def aasm_skipping_validations(state_machine_name)
           AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.skip_validation_on_save
+        end
+
+        def aasm_whiny_persistence(state_machine_name)
+          AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.whiny_persistence
         end
 
         def aasm_write_attribute(state, name=:default)

--- a/lib/aasm/version.rb
+++ b/lib/aasm/version.rb
@@ -1,3 +1,3 @@
 module AASM
-  VERSION = "5.0.0"
+  VERSION = "4.11.0"
 end

--- a/lib/aasm/version.rb
+++ b/lib/aasm/version.rb
@@ -1,3 +1,3 @@
 module AASM
-  VERSION = "4.10.1"
+  VERSION = "5.0.0"
 end

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -17,7 +17,7 @@ ActiveRecord::Migration.suppress_messages do
     t.string "right"
   end
 
-  %w(validators multiple_validators).each do |table_name|
+  %w(validators multiple_validators workers invalid_persistors multiple_invalid_persistors silent_persistors multiple_silent_persistors).each do |table_name|
     ActiveRecord::Migration.create_table table_name, :force => true do |t|
       t.string "name"
       t.string "status"
@@ -30,20 +30,6 @@ ActiveRecord::Migration.suppress_messages do
       t.string "status"
       t.integer "worker_id"
     end
-  end
-
-  ActiveRecord::Migration.create_table "workers", :force => true do |t|
-    t.string "name"
-    t.string "status"
-  end
-
-  ActiveRecord::Migration.create_table "invalid_persistors", :force => true do |t|
-    t.string "name"
-    t.string "status"
-  end
-  ActiveRecord::Migration.create_table "multiple_invalid_persistors", :force => true do |t|
-    t.string "name"
-    t.string "status"
   end
 
   ActiveRecord::Migration.create_table "fathers", :force => true do |t|

--- a/spec/models/silent_persistor.rb
+++ b/spec/models/silent_persistor.rb
@@ -1,0 +1,31 @@
+require 'active_record'
+
+class SilentPersistor < ActiveRecord::Base
+  include AASM
+  aasm :column => :status, :whiny_persistence => false do
+    state :sleeping, :initial => true
+    state :running
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+    event :sleep do
+      transitions :to => :sleeping, :from => :running
+    end
+  end
+  validates_presence_of :name
+end
+
+class MultipleSilentPersistor < ActiveRecord::Base
+  include AASM
+  aasm :left, :column => :status, :whiny_persistence => false do
+    state :sleeping, :initial => true
+    state :running
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+    event :sleep do
+      transitions :to => :sleeping, :from => :running
+    end
+  end
+  validates_presence_of :name
+end

--- a/spec/models/validator.rb
+++ b/spec/models/validator.rb
@@ -10,7 +10,7 @@ class Validator < ActiveRecord::Base
 
   include AASM
 
-  aasm :column => :status do
+  aasm :column => :status, :whiny_persistence => true do
     before_all_transactions :before_all_transactions
     after_all_transactions  :after_all_transactions
 
@@ -78,7 +78,7 @@ end
 class MultipleValidator < ActiveRecord::Base
 
   include AASM
-  aasm :left, :column => :status do
+  aasm :left, :column => :status, :whiny_persistence => true do
     state :sleeping, :initial => true
     state :running
     state :failed, :after_enter => :fail

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -386,6 +386,30 @@ describe 'transitions with persistence' do
 
     validator.name = nil
     expect(validator).not_to be_valid
+    expect { validator.run! }.to raise_error(ActiveRecord::RecordInvalid)
+    expect(validator).to be_sleeping
+
+    validator.reload
+    expect(validator).not_to be_running
+    expect(validator).to be_sleeping
+
+    validator.name = 'another name'
+    expect(validator).to be_valid
+    expect(validator.run!).to be_truthy
+    expect(validator).to be_running
+
+    validator.reload
+    expect(validator).to be_running
+    expect(validator).not_to be_sleeping
+  end
+
+  it 'should not store states for invalid models silently if configured' do
+    validator = MultipleSilentPersistor.create(:name => 'name')
+    expect(validator).to be_valid
+    expect(validator).to be_sleeping
+
+    validator.name = nil
+    expect(validator).not_to be_valid
     expect(validator.run!).to be_falsey
     expect(validator).to be_sleeping
 

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -387,6 +387,30 @@ describe 'transitions with persistence' do
 
     validator.name = nil
     expect(validator).not_to be_valid
+    expect { validator.run! }.to raise_error(ActiveRecord::RecordInvalid)
+    expect(validator).to be_sleeping
+
+    validator.reload
+    expect(validator).not_to be_running
+    expect(validator).to be_sleeping
+
+    validator.name = 'another name'
+    expect(validator).to be_valid
+    expect(validator.run!).to be_truthy
+    expect(validator).to be_running
+
+    validator.reload
+    expect(validator).to be_running
+    expect(validator).not_to be_sleeping
+  end
+
+  it 'should not store states for invalid models silently if configured' do
+    validator = SilentPersistor.create(:name => 'name')
+    expect(validator).to be_valid
+    expect(validator).to be_sleeping
+
+    validator.name = nil
+    expect(validator).not_to be_valid
     expect(validator.run!).to be_falsey
     expect(validator).to be_sleeping
 


### PR DESCRIPTION
@PragTob's suggestion from https://github.com/aasm/aasm/issues/262.