### PR TITLE
Allow AASM to Take A Logger Configuration

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 module AASM
   class Base
 
@@ -39,6 +41,9 @@ module AASM
 
       # Set to true to namespace reader methods and constants
       configure :namespace, false
+
+      # Configure a logger, with default being a Logger to STDERR
+      configure :logger, Logger.new(STDERR)
 
       # make sure to raise an error if no_direct_assignment is enabled
       # and attribute is directly assigned though
@@ -200,7 +205,7 @@ module AASM
              klass.defined_enums.values.any?{ |methods|
                  methods.keys{| enum | enum + '?' == method_name }
              })
-        warn "#{klass.name}: overriding method '#{method_name}'!"
+         @state_machine.config.logger.warn "#{klass.name}: overriding method '#{method_name}'!"
       end
 
       klass.send(:define_method, method_name, method_definition)

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -28,5 +28,8 @@ module AASM
 
     # namespace reader methods and constants
     attr_accessor :namespace
+
+    # Configure a logger, with default being a Logger to STDERR
+    attr_accessor :logger
   end
 end

--- a/spec/unit/override_warning_spec.rb
+++ b/spec/unit/override_warning_spec.rb
@@ -28,42 +28,59 @@ describe 'warns when overrides a method' do
   end
 
   describe 'state' do
-    class Base
-      def valid?; end
+    let(:base_klass) do
+      Class.new do
+        def valid?; end
+      end
     end
-    it do
-      expect { Base.send :include, Clumsy }.
-        to output(/Base: overriding method 'valid\?'!/).to_stderr
+
+    subject { base_klass.send :include, Clumsy }
+
+    it 'should log to warn' do
+      expect_any_instance_of(Logger).to receive(:warn).with(": overriding method 'valid?'!")
+      subject
     end
   end
 
   describe 'enum' do
-    class EnumBase
-      def valid?; end
+    let(:enum_base_klass) do
+      Class.new do
+        def valid?; end
+      end
     end
-    it "dosn't warn when overriding an enum" do
-      expect { EnumBase.send :include, WithEnumBase }.
-        not_to output(/EnumBase: overriding method 'valid\?'!/).to_stderr
+
+    subject { enum_base_klass.send :include, WithEnumBase }
+
+    it 'should not log to warn' do
+      expect_any_instance_of(Logger).to receive(:warn).never
+      subject
     end
   end
 
   describe 'event' do
     context 'may?' do
-      class Base
-        def may_save?; end
-        def save!; end
-        def save; end
+      let(:base_klass) do
+        Class.new do
+          def may_save?; end
+          def save!; end
+          def save; end
+        end
       end
-      let(:klass) { Base }
-      it do
-        expect { Base.send :include, Clumsy }.
-          to output(/Base: overriding method 'may_save\?'!/).to_stderr
-        expect { Base.send :include, Clumsy }.
-          to output(/Base: overriding method 'save!'!/).to_stderr
-        expect { Base.send :include, Clumsy }.
-          to output(/Base: overriding method 'save'!/).to_stderr
+
+      subject { base_klass.send :include, Clumsy }
+
+      it 'should log to warn' do
+        expect_any_instance_of(Logger).to receive(:warn).exactly(3).times do |logger, message|
+          expect(
+            [
+              ": overriding method 'may_save?'!",
+              ": overriding method 'save!'!",
+              ": overriding method 'save'!"
+            ]
+          ).to include(message)
+        end
+        subject
       end
     end
   end
-
 end


### PR DESCRIPTION
This is tangentially related to #369. In this PR, we're creating the ability to specify the AASM logger to warn against when a method is overridden. It currently logs to `Kernel#warn`.

http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-warn

This is is created as a separate PR in the event we feel that #369 is not the direction we want. Perhaps a combination of both might offer us greater flexibility, or perhaps not.