### PR TITLE
After and after_all_transitions_callback execution order

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ begin
   transition      guards
   old_state       before_exit
   old_state       exit
-                  after_all_transitions
   transition      after
+                  after_all_transitions
   new_state       before_enter
   new_state       enter
   ...update state...

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -34,8 +34,8 @@ module AASM::Core
     end
 
     def execute(obj, *args)
-      invoke_callbacks_compatible_with_guard(event.state_machine.global_callbacks[:after_all_transitions], obj, args)
       invoke_callbacks_compatible_with_guard(@after, obj, args)
+      invoke_callbacks_compatible_with_guard(event.state_machine.global_callbacks[:after_all_transitions], obj, args)
     end
 
     def ==(obj)

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -77,8 +77,8 @@ describe 'callbacks for the new DSL' do
       expect(callback).to receive(:exit_open).once.ordered
       # expect(callback).to receive(:event_guard).once.ordered.and_return(true)
       # expect(callback).to receive(:transition_guard).once.ordered.and_return(true)
-      expect(callback).to receive(:after_all_transitions).once.ordered
       expect(callback).to receive(:after_transition).once.ordered
+      expect(callback).to receive(:after_all_transitions).once.ordered
       expect(callback).to receive(:before_enter_closed).once.ordered
       expect(callback).to receive(:enter_closed).once.ordered
       expect(callback).to receive(:aasm_write_state).once.ordered.and_return(true)  # this is when the state changes
@@ -113,8 +113,8 @@ describe 'callbacks for the new DSL' do
       expect(callback).to receive(:exit_open).once.ordered
       # expect(callback).to receive(:event_guard).once.ordered.and_return(true)
       # expect(callback).to receive(:transition_guard).once.ordered.and_return(true)
-      expect(callback).to receive(:after_all_transitions).once.ordered
       expect(callback).to receive(:after_transition).once.ordered
+      expect(callback).to receive(:after_all_transitions).once.ordered
       expect(callback).to receive(:before_enter_closed).once.ordered
       expect(callback).to receive(:enter_closed).once.ordered
       expect(callback).to receive(:aasm_write_state).once.ordered.and_return(true)   # this is when the state changes


### PR DESCRIPTION
`after transition` should be called before `after_all_transitions`, like after event is called before after_all_events.But currently, `after` transition is called after `after_all_transitions`.
