### PR TITLE
Clear transition failures between attempts.

### DIFF
--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -29,11 +29,13 @@ module AASM::Core
     end
 
     def allowed?(obj, *args)
+      prepare_for_transition!
       invoke_callbacks_compatible_with_guard(@guards, obj, args, :guard => true) &&
       invoke_callbacks_compatible_with_guard(@unless, obj, args, :unless => true)
     end
 
     def execute(obj, *args)
+      prepare_for_transition!
       invoke_callbacks_compatible_with_guard(event.state_machine.global_callbacks[:after_all_transitions], obj, args)
       invoke_callbacks_compatible_with_guard(@after, obj, args)
     end
@@ -51,6 +53,14 @@ module AASM::Core
     end
 
     private
+
+    def prepare_for_transition!
+      clear_failures!
+    end
+
+    def clear_failures!
+      @failures.clear
+    end
 
     def invoke_callbacks_compatible_with_guard(code, record, args, options={})
       if record.respond_to?(:aasm)

--- a/spec/unit/callback_multiple_spec.rb
+++ b/spec/unit/callback_multiple_spec.rb
@@ -49,8 +49,7 @@ describe 'callbacks for the new DSL' do
 
     expect {
       callback.left_close!
-    }.to raise_error(AASM::InvalidTransition, "Event 'left_close' cannot transition from 'open'. Failed callback(s): [:after_transition, :event_guard].")
-
+    }.to raise_error(AASM::InvalidTransition, "Event 'left_close' cannot transition from 'open'. Failed callback(s): [:event_guard].")
   end
 
   it "handles private callback methods as well" do
@@ -88,7 +87,7 @@ describe 'callbacks for the new DSL' do
 
       expect {
         callback.left_close!
-      }.to raise_error(AASM::InvalidTransition, "Event 'left_close' cannot transition from 'open'. Failed callback(s): [:after_transition, :event_guard, :transition_guard].")
+      }.to raise_error(AASM::InvalidTransition, "Event 'left_close' cannot transition from 'open'. Failed callback(s): [:transition_guard].")
     end
 
     it "does not run transition_guard twice for multiple permitted transitions" do
@@ -287,7 +286,7 @@ describe 'event callbacks' do
       expect(@foo).to receive(:aasm_event_failed).with(:null, :open)
       expect{
         @foo.null
-      }.to raise_error(AASM::InvalidTransition, "Event 'null' cannot transition from 'open'. Failed callback(s): [:always_false, :always_false].")
+      }.to raise_error(AASM::InvalidTransition, "Event 'null' cannot transition from 'open'. Failed callback(s): [:always_false].")
     end
 
     it 'should not call it if persist fails for bang fire' do

--- a/spec/unit/transition_spec.rb
+++ b/spec/unit/transition_spec.rb
@@ -158,6 +158,18 @@ describe AASM::Core::Transition, '- when performing guard checks' do
     expect(st.failures).to eq [:test]
   end
 
+  it 'should clear failures array between attempts' do
+    opts = {:from => 'foo', :to => 'bar', :guard => :test}
+    st = AASM::Core::Transition.new(event, opts)
+
+    obj = double('object')
+    expect(obj).to receive(:test).exactly(3).times
+
+    3.times { st.allowed?(obj) }
+
+    expect(st.failures).to eq [:test]
+  end
+
   it 'should call the method on the object if unless is a symbol' do
     opts = {:from => 'foo', :to => 'bar', :unless => :test}
     st = AASM::Core::Transition.new(event, opts)


### PR DESCRIPTION
This is related to issue #383.

The failures array is not being cleared between transition attempts, preventing an object from transitioning even if the guards would normally permit it.

A few specs needed to be modified, as they were expecting this behavior.