### PR TITLE
Added `to_states_for_state` method

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -186,6 +186,15 @@ module AASM
       end
     end
 
+    def to_states_for_state(state, options={})
+      if options[:transition]
+        @state_machine.events[options[:transition]].transitions_from_state(state).flatten.map(&:to).flatten
+      else
+
+        events.map {|e| e.transitions_from_state(state)}.flatten.map(&:to).flatten
+      end
+    end
+
     private
 
     def default_column

--- a/spec/unit/inspection_multiple_spec.rb
+++ b/spec/unit/inspection_multiple_spec.rb
@@ -187,6 +187,19 @@ describe 'aasm.from_states_for_state' do
   end
 end
 
+describe 'aasm.to_states_for_state' do
+  it "should return all to states for a state" do
+    expect(ComplexExampleMultiple.aasm(:left)).to respond_to(:to_states_for_state)
+    tos = ComplexExampleMultiple.aasm(:left).to_states_for_state(:active)
+    [:suspended, :deleted].each {|to| expect(tos).to include(to)}
+  end
+
+  it "should return to states for a state for a particular transition only" do
+    tos = ComplexExampleMultiple.aasm(:left).to_states_for_state(:active, :transition => :left_suspend)
+    [:suspended].each {|to| expect(tos).to include(to)}
+  end
+end
+
 describe 'permitted events' do
   let(:foo) {FooMultiple.new}
 

--- a/spec/unit/inspection_spec.rb
+++ b/spec/unit/inspection_spec.rb
@@ -116,6 +116,19 @@ describe 'aasm.from_states_for_state' do
   end
 end
 
+describe 'aasm.to_states_for_state' do
+  it "should return all to states for a state" do
+    expect(ComplexExample.aasm).to respond_to(:to_states_for_state)
+    tos = ComplexExample.aasm.to_states_for_state(:active)
+    [:suspended, :deleted].each {|to| expect(tos).to include(to)}
+  end
+
+  it "should return to states for a state for a particular transition only" do
+    tos = ComplexExample.aasm.to_states_for_state(:active, :transition => :suspend)
+    [:suspended].each {|to| expect(tos).to include(to)}
+  end
+end
+
 describe 'permitted events' do
   let(:foo) {Foo.new}
 


### PR DESCRIPTION
Useful when having events supporting multiple manual transitions:

```
    event :reopen do
      transitions :from => :done,
                  :to => [:open, :pending],
                  :before => :clean_it_up!
    end
```
