### PR TITLE
The dependency `tins` 1.7.0 officially require ruby >= 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'mongoid', '~>4.0' if Gem::Version.create(RUBY_VERSION.dup) >= Gem::Version.
 gem 'sequel'
 
 platforms :ruby_19 do
-  gem 'tins', '~> 1.6.0'
+  gem 'tins', '1.6.0'
 end
 # testing dynamoid
 # gem 'dynamoid', '~> 1'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem "rails", "~>4.2"
 gem 'mongoid', '~>4.0' if Gem::Version.create(RUBY_VERSION.dup) >= Gem::Version.create('1.9.3')
 gem 'sequel'
 
+platforms :ruby_19 do
+  gem 'tins', '~> 1.6.0'
+end
 # testing dynamoid
 # gem 'dynamoid', '~> 1'
 # gem 'aws-sdk', '~>2'


### PR DESCRIPTION
- https://github.com/sferik/rails_admin/issues/2464