### PR TITLE
Change Aasm to AASM in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ gem 'aasm'
 
 ### Generators
 
-After installing Aasm you can run generator:
+After installing AASM you can run generator:
 
 ```sh
 % rails generate aasm NAME [COLUMN_NAME]


### PR DESCRIPTION
Thank you for nice gem 👍 
I rewrite `Aasm` to `AASM` in README.md