### PR TITLE
added custom-name to generator to avoid uninitialized constant error

### DIFF
--- a/lib/generators/active_record/aasm_generator.rb
+++ b/lib/generators/active_record/aasm_generator.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
       def copy_aasm_migration
         if model_exists?
-          migration_template "migration_existing.rb", "db/migrate/add_aasm_state_to_#{table_name}.rb"
+          migration_template "migration_existing.rb", "db/migrate/add_#{column_name}_to_#{table_name}.rb"
         else
           migration_template "migration.rb", "db/migrate/aasm_create_#{table_name}.rb"
         end

--- a/spec/generators/active_record_generator_spec.rb
+++ b/spec/generators/active_record_generator_spec.rb
@@ -36,4 +36,9 @@ describe ActiveRecord::Generators::AASMGenerator, type: :generator do
     assert_migration "db/migrate/add_aasm_state_to_jobs.rb"
   end
 
+  it "add custom aasm_column in existing model" do
+    run_generator %w(job state)
+    assert_migration "db/migrate/add_state_to_jobs.rb"
+  end
+
 end


### PR DESCRIPTION
I added the column name to the generator including an additional spec for future use. Let me know if there are any downsides to my changes.