### PR TITLE
Whiny persistence for Mongoid

### DIFF
--- a/spec/models/mongoid/invalid_persistor_mongoid.rb
+++ b/spec/models/mongoid/invalid_persistor_mongoid.rb
@@ -1,0 +1,39 @@
+class InvalidPersistorMongoid
+  include Mongoid::Document
+  include AASM
+
+  field :name
+  field :status
+
+  aasm :left, column: :status, skip_validation_on_save: true do
+    state :sleeping, :initial => true
+    state :running
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+    event :sleep do
+      transitions :to => :sleeping, :from => :running
+    end
+  end
+  validates_presence_of :name
+end
+
+class MultipleInvalidPersistorMongoid
+  include Mongoid::Document
+  include AASM
+
+  field :name
+  field :status
+
+  aasm :left, column: :status, skip_validation_on_save: true do
+    state :sleeping, :initial => true
+    state :running
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+    event :sleep do
+      transitions :to => :sleeping, :from => :running
+    end
+  end
+  validates_presence_of :name
+end

--- a/spec/models/mongoid/silent_persistor_mongoid.rb
+++ b/spec/models/mongoid/silent_persistor_mongoid.rb
@@ -1,0 +1,39 @@
+class SilentPersistorMongoid
+  include Mongoid::Document
+  include AASM
+
+  field :name
+  field :status
+
+  aasm :left, column: :status, whiny_persistence: false do
+    state :sleeping, :initial => true
+    state :running
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+    event :sleep do
+      transitions :to => :sleeping, :from => :running
+    end
+  end
+  validates_presence_of :name
+end
+
+class MultipleSilentPersistorMongoid
+  include Mongoid::Document
+  include AASM
+
+  field :name
+  field :status
+
+  aasm :left, column: :status, whiny_persistence: false do
+    state :sleeping, :initial => true
+    state :running
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+    event :sleep do
+      transitions :to => :sleeping, :from => :running
+    end
+  end
+  validates_presence_of :name
+end

--- a/spec/models/mongoid/validator_mongoid.rb
+++ b/spec/models/mongoid/validator_mongoid.rb
@@ -1,0 +1,100 @@
+class ValidatorMongoid
+  include Mongoid::Document
+  include AASM
+
+  field :name
+  field :status
+
+  attr_accessor :invalid
+
+  validate do |model|
+    errors.add(:validator, "invalid") if invalid
+  end
+
+  include AASM
+
+  aasm :column => :status, :whiny_persistence => true do
+    before_all_transactions :before_all_transactions
+    after_all_transactions  :after_all_transactions
+
+    state :sleeping, :initial => true
+    state :running
+    state :failed, :after_enter => :fail
+
+    event :run, :after_commit => :change_name! do
+      transitions :to => :running, :from => :sleeping
+    end
+
+    event :sleep do
+      after_commit do |name|
+        change_name_on_sleep name
+      end
+      transitions :to => :sleeping, :from => :running
+    end
+
+    event :fail do
+      transitions :to => :failed, :from => [:sleeping, :running]
+    end
+  end
+
+  validates_presence_of :name
+
+  def change_name!
+    self.name = "name changed"
+    save!
+  end
+
+  def change_name_on_sleep name
+    self.name = name
+    save!
+  end
+
+  def fail
+    raise StandardError.new('failed on purpose')
+  end
+end
+
+class MultipleValidatorMongoid
+  include Mongoid::Document
+  include AASM
+
+  field :name
+  field :status
+
+  attr_accessor :invalid
+
+  aasm :left, :column => :status, :whiny_persistence => true do
+    state :sleeping, :initial => true
+    state :running
+    state :failed, :after_enter => :fail
+
+    event :run, :after_commit => :change_name! do
+      transitions :to => :running, :from => :sleeping
+    end
+    event :sleep do
+      after_commit do |name|
+        change_name_on_sleep name
+      end
+      transitions :to => :sleeping, :from => :running
+    end
+    event :fail do
+      transitions :to => :failed, :from => [:sleeping, :running]
+    end
+  end
+
+  validates_presence_of :name
+
+  def change_name!
+    self.name = "name changed"
+    save!
+  end
+
+  def change_name_on_sleep name
+    self.name = name
+    save!
+  end
+
+  def fail
+    raise StandardError.new('failed on purpose')
+  end
+end

--- a/spec/unit/persistence/mongoid_persistence_spec.rb
+++ b/spec/unit/persistence/mongoid_persistence_spec.rb
@@ -84,5 +84,86 @@ if defined?(Mongoid::Document)
 
     end
 
+    describe 'transitions with persistence' do
+
+      it 'should work for valid models' do
+        valid_object = ValidatorMongoid.create(:name => 'name')
+        expect(valid_object).to be_sleeping
+        valid_object.status = :running
+        expect(valid_object).to be_running
+      end
+
+      it 'should not store states for invalid models' do
+        validator = ValidatorMongoid.create(:name => 'name')
+        expect(validator).to be_valid
+        expect(validator).to be_sleeping
+
+        validator.name = nil
+        expect(validator).not_to be_valid
+        expect { validator.run! }.to raise_error(Mongoid::Errors::Validations)
+        expect(validator).to be_sleeping
+
+        validator.reload
+        expect(validator).not_to be_running
+        expect(validator).to be_sleeping
+
+        validator.name = 'another name'
+        expect(validator).to be_valid
+        expect(validator.run!).to be_truthy
+        expect(validator).to be_running
+
+        validator.reload
+        expect(validator).to be_running
+        expect(validator).not_to be_sleeping
+      end
+
+      it 'should not store states for invalid models silently if configured' do
+        validator = SilentPersistorMongoid.create(:name => 'name')
+        expect(validator).to be_valid
+        expect(validator).to be_sleeping
+
+        validator.name = nil
+        expect(validator).not_to be_valid
+        expect(validator.run!).to be_falsey
+        expect(validator).to be_sleeping
+
+        validator.reload
+        expect(validator).not_to be_running
+        expect(validator).to be_sleeping
+
+        validator.name = 'another name'
+        expect(validator).to be_valid
+        expect(validator.run!).to be_truthy
+        expect(validator).to be_running
+
+        validator.reload
+        expect(validator).to be_running
+        expect(validator).not_to be_sleeping
+      end
+
+      it 'should store states for invalid models if configured' do
+        persistor = InvalidPersistorMongoid.create(:name => 'name')
+        expect(persistor).to be_valid
+        expect(persistor).to be_sleeping
+
+        persistor.name = nil
+
+        expect(persistor).not_to be_valid
+        expect(persistor.run!).to be_truthy
+        expect(persistor).to be_running
+
+        persistor = InvalidPersistorMongoid.find(persistor.id)
+
+        persistor.valid?
+        expect(persistor).to be_valid
+        expect(persistor).to be_running
+        expect(persistor).not_to be_sleeping
+
+        persistor.reload
+        expect(persistor).to be_running
+        expect(persistor).not_to be_sleeping
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I've recently found out that when we're relying on switching the state of the invalid model with the bang! method, AASM quetly persists the model with all the dirty values, no questions asked.

It seems that the ActiveRecord adapter has already been fixed by implementing whiny_transitions, so I've ported the logic of ActiveRecordPersistence to MongoidPersistence and included the corresponding tests (it seems that Mongoid coverage is quite outdated).
