### PR TITLE
Allow multiple transitions in a single event with the same to and from states

### DIFF
--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -128,12 +128,13 @@ module AASM::Core
 
       transitions.each do |transition|
         next if to_state and !Array(transition.to).include?(to_state)
-        if (options.key?(:may_fire) && Array(transition.to).include?(options[:may_fire])) ||
+        if (options.key?(:may_fire) && transition.eql?(options[:may_fire])) ||
            (!options.key?(:may_fire) && transition.allowed?(obj, *args))
-          result = to_state || Array(transition.to).first
+
           if options[:test_only]
-            # result = true
+            result = transition
           else
+            result = to_state || Array(transition.to).first
             Array(transition.to).each {|to| @valid_transitions[to] = transition }
             transition.execute(obj, *args)
           end

--- a/spec/models/multiple_transitions_that_differ_only_by_guard.rb
+++ b/spec/models/multiple_transitions_that_differ_only_by_guard.rb
@@ -1,0 +1,31 @@
+class MultipleTransitionsThatDifferOnlyByGuard
+  include AASM
+
+  attr_accessor :executed_correctly
+
+  aasm do
+    state :start, :initial => true
+    state :gone
+
+    event :go do
+      transitions :from => :start, :to => :gone, :guard => :returns_false, :after => :this_should_not_execute
+      transitions :from => :start, :to => :gone, :guard => :returns_true, :after => :this_should_execute
+    end
+  end
+
+  def returns_false
+    false
+  end
+
+  def returns_true
+    true
+  end
+
+  def this_should_not_execute
+    raise RuntimeError, "This should not execute"
+  end
+
+  def this_should_execute
+    self.executed_correctly = true
+  end
+end

--- a/spec/models/multiple_transitions_that_differ_only_by_guard.rb
+++ b/spec/models/multiple_transitions_that_differ_only_by_guard.rb
@@ -1,7 +1,7 @@
 class MultipleTransitionsThatDifferOnlyByGuard
   include AASM
 
-  attr_accessor :executed_correctly
+  attr_accessor :executed_second
 
   aasm do
     state :start, :initial => true
@@ -26,6 +26,6 @@ class MultipleTransitionsThatDifferOnlyByGuard
   end
 
   def this_should_execute
-    self.executed_correctly = true
+    self.executed_second = true
   end
 end

--- a/spec/unit/multiple_transitions_that_differ_only_by_guard_spec.rb
+++ b/spec/unit/multiple_transitions_that_differ_only_by_guard_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe "multiple transitions that differ only by guard" do
+  let(:job) { MultipleTransitionsThatDifferOnlyByGuard.new }
+
+  it 'does not follow the first transition if its guard fails' do
+    expect{job.go}.not_to raise_error
+  end
+end

--- a/spec/unit/multiple_transitions_that_differ_only_by_guard_spec.rb
+++ b/spec/unit/multiple_transitions_that_differ_only_by_guard_spec.rb
@@ -6,4 +6,9 @@ describe "multiple transitions that differ only by guard" do
   it 'does not follow the first transition if its guard fails' do
     expect{job.go}.not_to raise_error
   end
+
+  it 'executes the second transition\'s callbacks' do
+    job.go
+    expect(job.executed_second).to be_truthy
+  end
 end


### PR DESCRIPTION
As reported in https://github.com/aasm/aasm/issues/372 and https://github.com/aasm/aasm/issues/362, if two transitions in the same event have the same `to` and `from` states but differ in their guards, if any transition is valid, the first transition is the one that's always executed. This PR attempts to resolve that issue.