### PR TITLE
Update README.md - Active Record

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,8 +540,10 @@ job.run   # not saved
 job.run!  # saved
 ```
 
-Saving includes running all validations on the `Job` class, and returns `true` if
-successful or `false` if errors occur. Exceptions are not raised.
+Saving includes running all validations on the `Job` class. If
+`whiny_persistence` flag is set to `true`, exception is raised in case of
+failure. If `whiny_persistence` flag is set to false, methods with a bang return
+`true` if the state transition is successful or `false` if an error occurs.
 
 If you want make sure the state gets saved without running validations (and
 thereby maybe persisting an invalid object state), simply tell AASM to skip the


### PR DESCRIPTION
Changes in #366 cause ActiveRecord persistence to throw exceptions if `whiny_persistence` flag is set. Updating README to reflect that change.
