### PR TITLE
Patch `allow_event` to accept event with custom arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,9 @@ expect(multiple).to allow_event(:start).on(:move)
 expect(multiple).to_not allow_event(:stop).on(:move)
 expect(multiple).to allow_transition_to(:processing).on(:move)
 expect(multiple).to_not allow_transition_to(:sleeping).on(:move)
+# allow_event also accepts arguments
+expect(job).to allow_event(:run).with(:defragmentation)
+
 ```
 
 ## <a id="installation">Installation ##

--- a/lib/aasm/rspec/allow_event.rb
+++ b/lib/aasm/rspec/allow_event.rb
@@ -1,11 +1,15 @@
 RSpec::Matchers.define :allow_event do |event|
   match do |obj|
     @state_machine_name ||= :default
-    obj.aasm(@state_machine_name).may_fire_event?(event)
+    obj.aasm(@state_machine_name).may_fire_event?(event, *@args)
   end
 
   chain :on do |state_machine_name|
     @state_machine_name = state_machine_name
+  end
+
+  chain :with do |*args|
+    @args = args
   end
 
   description do

--- a/spec/models/simple_example.rb
+++ b/spec/models/simple_example.rb
@@ -11,5 +11,15 @@ class SimpleExample
     event :authorise do
       transitions :from => :filled_out, :to => :authorised
     end
+
+    event :fill_out_with_args do
+      transitions :guard => [:arg_is_valid?],
+                  :from => :initialised,
+                  :to => :filled_out
+    end
+  end
+
+  def arg_is_valid?(arg)
+    return arg
   end
 end

--- a/spec/unit/rspec_matcher_spec.rb
+++ b/spec/unit/rspec_matcher_spec.rb
@@ -63,6 +63,11 @@ describe 'state machine' do
       expect(simple).to allow_event :authorise
     end
 
+    it "works with custom arguments" do
+      expect(simple).to allow_event(:fill_out_with_args).with(true)
+      expect(simple).to_not allow_event(:fill_out_with_args).with(false)
+    end
+
     it "works for multiple state machines" do
       expect(multiple).to allow_event(:walk).on(:move)
       expect(multiple).to_not allow_event(:hold).on(:move)


### PR DESCRIPTION
Pass arguments for `event` hooks, similar to `on_event` for `state` hooks.