### PR TITLE
Add before_success callback on event layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ begin
   new_state       before_enter
   new_state       enter
   ...update state...
+  event           before_success      # if persist successful
   transition      success             # if persist successful
   event           success             # if persist successful
   old_state       after_exit
@@ -921,13 +922,13 @@ end
 
 ```ruby
 # show all states
-Job.aasm.states.map(&:name) 
+Job.aasm.states.map(&:name)
 #=> [:sleeping, :running, :cleaning]
 
 job = Job.new
 
 # show all permitted states (from initial state)
-job.aasm.states(:permitted => true).map(&:name) 
+job.aasm.states(:permitted => true).map(&:name)
 #=> [:running]
 
 job.run
@@ -935,7 +936,7 @@ job.aasm.states(:permitted => true).map(&:name)
 #=> [:sleeping]
 
 # show all non permitted states
-job.aasm.states(:permitted => false).map(&:name) 
+job.aasm.states(:permitted => false).map(&:name)
 #=> [:cleaning]
 
 # show all possible (triggerable) events from the current state

--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -150,6 +150,7 @@ private
       persist_successful = aasm(state_machine_name).set_current_state_with_persistence(new_state_name)
       if persist_successful
         yield if block_given?
+        event.fire_callbacks(:before_success, self)
         event.fire_transition_callbacks(self, *process_args(event, old_state.name, *args))
         event.fire_callbacks(:success, self)
       end

--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -22,6 +22,7 @@ module AASM::Core
         :before_transaction,
         :ensure,
         :error,
+        :before_success,
         :success,
       ], &block) if block
     end

--- a/spec/models/callbacks/basic.rb
+++ b/spec/models/callbacks/basic.rb
@@ -43,6 +43,7 @@ module Callbacks
             :before => :before_event,
             :after => :after_event,
             :guard => :event_guard,
+            :before_success => :event_before_success,
             :ensure => :ensure_event do
         transitions :to => :closed, :from => [:open],
                     :guard => :transition_guard,
@@ -78,6 +79,8 @@ module Callbacks
     def event_guard;              log('event_guard');         !@fail_event_guard;      end
     def transition_guard;         log('transition_guard');    !@fail_transition_guard; end
 
+    def event_before_success;     log('event_before_success'); end
+
     def after_transition;         log('after_transition');        end
     def after_all_transitions;    log('after_all_transitions');   end
 
@@ -86,8 +89,8 @@ module Callbacks
     def after_event;              log('after_event');         end
     def after_all_events;         log('after_all_events');    end
 
-    def after_transition;     log('after_transition');    end
-    def success_transition;   log('transition_success');  end
+    def after_transition;         log('after_transition');    end
+    def success_transition;       log('transition_success');  end
 
     def ensure_event;             log('ensure');              end
     def ensure_on_all_events;     log('ensure');              end

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -118,6 +118,7 @@ describe 'callbacks for the new DSL' do
       expect(callback).to receive(:before_enter_closed).once.ordered
       expect(callback).to receive(:enter_closed).once.ordered
       expect(callback).to receive(:aasm_write_state).once.ordered.and_return(true)   # this is when the state changes
+      expect(callback).to receive(:event_before_success).once.ordered
       expect(callback).to receive(:success_transition).once.ordered.and_return(true) # these should be after the state changes
       expect(callback).to receive(:after_exit_open).once.ordered
       expect(callback).to receive(:after_enter_closed).once.ordered
@@ -143,6 +144,7 @@ describe 'callbacks for the new DSL' do
     expect(callback).to_not receive(:before_enter_closed)
     expect(callback).to_not receive(:enter_closed)
     expect(callback).to_not receive(:aasm_write_state)
+    expect(callback).to_not receive(:event_before_success)
     expect(callback).to_not receive(:success_transition)
     expect(callback).to_not receive(:after_exit_open)
     expect(callback).to_not receive(:after_enter_closed)
@@ -186,6 +188,7 @@ describe 'callbacks for the new DSL' do
         expect(callback).to_not receive(:before_enter_closed)
         expect(callback).to_not receive(:enter_closed)
         expect(callback).to_not receive(:aasm_write_state)
+        expect(callback).to_not receive(:event_before_success)
         expect(callback).to_not receive(:success_transition)
         expect(callback).to_not receive(:after_exit_open)
         expect(callback).to_not receive(:after_enter_closed)
@@ -217,6 +220,7 @@ describe 'callbacks for the new DSL' do
         expect(callback).to receive(:after).once.ordered
 
         expect(callback).to_not receive(:transitioning)
+        expect(callback).to_not receive(:event_before_success)
         expect(callback).to_not receive(:success_transition)
         expect(callback).to_not receive(:before_enter_closed)
         expect(callback).to_not receive(:enter_closed)
@@ -240,6 +244,7 @@ describe 'callbacks for the new DSL' do
       expect(callback).to_not receive(:before_enter_closed)
       expect(callback).to_not receive(:enter_closed)
       expect(callback).to_not receive(:aasm_write_state)
+      expect(callback).to_not receive(:event_before_success)
       expect(callback).to_not receive(:success_transition)
       expect(callback).to_not receive(:after_exit_open)
       expect(callback).to_not receive(:after_enter_closed)


### PR DESCRIPTION
Sometimes you need to call some global callback on event **before** some transition callback but **after** state was persisted  successful. I didn't find such callback in the current codebase so I introduced `before_success` callback.

Here is some simple case where it can be useful
```ruby
event :send do
  before_success do
    # update object here, to make sure we notify recipient or sender with up-to-date object
    update! color: 'red'
  end

  transition from: :recipient_turn, to: :sender_turn do
    success { notify :sender }
  end

  transition from: :sender_turn, to: :recipient_turn do
    success { notify :recipient }
  end
end
```