### PR TITLE
Add section about "bang" methods to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ the transition succeeds :
   end
 ```
 
+### Bang Methods
+
+Each even method also comes in a "bang" flavor. The "bang" version, e.g. `job.run!`, automatically persists the record after a successful state transition. It is important to note that the "bang" in this case does not have anything to the event raising an exception or not.
+
+```ruby
+job.may_run? # => true
+job.run!     # => true, and the job has also been saved to the database
+```
+
 ### Callbacks
 
 You can define a number of callbacks for your transitions. These methods will be

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ the transition succeeds :
 
 ### Bang Methods
 
-Each even method also comes in a "bang" flavor. The "bang" version, e.g. `job.run!`, **automatically persists** the record after a successful state transition. It is important to note that the "bang" in this case _does not have anything to do with the event raising an exception_ or not.
+Each event method also comes in a "bang" flavor. The "bang" version, e.g. `job.run!`, **automatically persists** the record after a successful state transition. It is important to note that the "bang" in this case _does not have anything to do with the event raising an exception_ or not.
 
 ```ruby
 job.may_run? # => true

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ the transition succeeds :
 
 ### Bang Methods
 
-Each even method also comes in a "bang" flavor. The "bang" version, e.g. `job.run!`, automatically persists the record after a successful state transition. It is important to note that the "bang" in this case does not have anything to the event raising an exception or not.
+Each even method also comes in a "bang" flavor. The "bang" version, e.g. `job.run!`, **automatically persists** the record after a successful state transition. It is important to note that the "bang" in this case _does not have anything to do with the event raising an exception_ or not.
 
 ```ruby
 job.may_run? # => true


### PR DESCRIPTION
First, apologies if this isn't entirely accurate. I stumbled upon this understanding and didn't see it laid out clearly in the readme.

Basically for some reason I had in my mind that the "bang" methods corresponded to error failures rather than persistence. The readme makes it obvious that errors are the default behavior, but it sort of glazes over the persistence thing.

Hope this helps! Thanks for your hard work on the library :)