### PR TITLE
Search unscoped class when saving state without validation

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -103,7 +103,7 @@ module AASM
       private
 
         def aasm_update_column(name, value)
-          self.class.where(self.class.primary_key => self.id).update_all(self.class.aasm(name).attribute_name => value) == 1
+          self.class.unscoped.where(self.class.primary_key => self.id).update_all(self.class.aasm(name).attribute_name => value) == 1
         end
 
         def aasm_rollback(name, old_value)

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -156,7 +156,8 @@ if defined?(ActiveRecord)
             # parameters in the middle of the chain, so we need to use
             # intermediate object instead.
             obj = double(Object, update_all: 1)
-            allow(MultipleGate).to receive(:where).and_return(obj)
+            allow(MultipleGate).to receive_message_chain(:unscoped, :where)
+              .and_return(obj)
 
             gate.aasm_write_state state_sym, :left
 


### PR DESCRIPTION
Records that are outside of `default_scope` on ActiveRecord don't transition when `skip_validation_on_save: true`. I fixed the issue by searching for the record with `unscoped.where` instead of just `.where`. 

