### PR TITLE
Add documentation about `aasm_event_failed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ Note that when passing arguments to a state transition, the first argument must 
 In case of an error during the event processing the error is rescued and passed to `:error`
 callback, which can handle it or re-raise it for further propagation.
 
+Also, you can define a method that will be called if any event fails:
+
+```
+def aasm_event_failed(event_name, new_state)
+  # use custom exception/messages, report metrics, etc
+end
+```
+
 During the transition's `:after` callback (and reliably only then, or in the global
 `after_all_transitions` callback) you can access the originating state (the from-state)
 and the target state (the to state), like this:


### PR DESCRIPTION
There are specs about this behavior, but it is not explicitly documented.

The code is in [lib/aasm/aasm.rb#192](https://github.com/aasm/aasm/blob/8534b62b8175f953f22d3c2b2fd7591101be9ca3/lib/aasm/aasm.rb#L192) and the specs are in [spec/unit/callback_multiple_spec.rb](https://github.com/aasm/aasm/blob/c73f883e1cb1891df6fde749378ae775eb7cc000/spec/unit/callback_multiple_spec.rb#L273) and [spec/unit/callbacks_spec.rb](https://github.com/aasm/aasm/blob/0629daae84ab1f073418ee92cd249b97fc917453/spec/unit/callbacks_spec.rb#L397).

I used it to raise a custom exception with a message including object data for debugging purpose.
