### PR TITLE
Make errors more inspectable by settings message

### DIFF
--- a/lib/aasm/errors.rb
+++ b/lib/aasm/errors.rb
@@ -7,10 +7,7 @@ module AASM
 
     def initialize(object, event_name, state_machine_name, failures = [])
       @object, @event_name, @originating_state, @failures = object, event_name, object.aasm(state_machine_name).current_state, failures
-    end
-
-    def message
-      "Event '#{event_name}' cannot transition from '#{originating_state}'. #{reasoning}"
+      super("Event '#{event_name}' cannot transition from '#{originating_state}'. #{reasoning}")
     end
 
     def reasoning


### PR DESCRIPTION
When message is set as variable, instead of redefining `message`
method, the message will be used in `inspect` and `to_s` calls,
both implicit and explicit, which improves logs readability and
simmplifies debugging in the irb.

Here are some examples:

```ruby
# That's how it is done now in AASM.
class TestException1 < RuntimeError
  def initialize(arg1, arg2)
    @arg1, @arg2 = arg1, arg2
  end

  def message
    "#{@arg1} #{@arg2}"
  end
end

# That's what purposed by this PR
class TestException2 < RuntimeError
  def initialize(arg1, arg2)
    @arg1, @arg2 = arg1, arg2
    super("#{@arg1} #{@arg2}")
  end
end

raise TestException1.new("some", "message") rescue err1 = $!
raise TestException2.new("some", "message") rescue err2 = $!

"Got error: #{err1}"
#> "Got error: TestException1"
err1.inspect
#> "#<TestException1: TestException1>"
err1.to_s
#> "TestException1"

"Got error: #{err2}"
#> "Got error: some message"
err2.inspect
#> "#<TestException2: some message>"
err2.to_s
#> "some message"
```