### PR TITLE
Updates README with correct method signature for aasm_event_failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ callback, which can handle it or re-raise it for further propagation.
 Also, you can define a method that will be called if any event fails:
 
 ```
-def aasm_event_failed(event_name, new_state)
+def aasm_event_failed(event_name, old_state_name)
   # use custom exception/messages, report metrics, etc
 end
 ```


### PR DESCRIPTION
According to [aasm.rb](https://github.com/aasm/aasm/blob/8534b62b8175f953f22d3c2b2fd7591101be9ca3/lib/aasm/aasm.rb#L185), this handler is called with the old state name, not the new state.

It could be debated that in the case of a failed transition, "old state" and "new state" both refer to the original state (not the destination), but that's not immediately clear.