### PR TITLE
Fix guard checking when from is not provided

### DIFF
--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -96,7 +96,7 @@ module AASM::Core
           @transitions << AASM::Core::Transition.new(self, attach_event_guards(definitions.merge(:from => s.to_sym)), &block)
         end
         # Create a transition if :to is specified without :from (transitions from ANY state)
-        if @transitions.empty? && definitions[:to]
+        if !definitions[:from] && definitions[:to]
           @transitions << AASM::Core::Transition.new(self, attach_event_guards(definitions), &block)
         end
       end

--- a/spec/models/guardian_without_from_specified.rb
+++ b/spec/models/guardian_without_from_specified.rb
@@ -1,0 +1,18 @@
+class GuardianWithoutFromSpecified
+  include AASM
+
+  aasm do
+    state :alpha, :initial => true
+    state :beta
+    state :gamma
+
+    event :use_guards_where_the_first_fails do
+      transitions :to => :beta,  :guard => :fail
+      transitions :to => :gamma, :guard => :succeed
+    end
+  end
+
+
+  def fail; false; end
+  def succeed; true; end
+end

--- a/spec/unit/guard_without_from_specified_spec.rb
+++ b/spec/unit/guard_without_from_specified_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "transitions withour from specified" do
+describe "transitions without from specified" do
   let(:guardian) { GuardianWithoutFromSpecified.new }
 
   it "allows the transitions if guard succeeds" do

--- a/spec/unit/guard_without_from_specified_spec.rb
+++ b/spec/unit/guard_without_from_specified_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe "transitions withour from specified" do
+  let(:guardian) { GuardianWithoutFromSpecified.new }
+
+  it "allows the transitions if guard succeeds" do
+    expect { guardian.use_guards_where_the_first_fails! }.to_not raise_error
+    expect(guardian).to be_gamma
+  end
+end


### PR DESCRIPTION
Fixing https://github.com/aasm/aasm/issues/454. Lack of `:from` option in transition resulted in incorrect guard checking. This pr solves the issue.