### PR TITLE
Add header to deep link to lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,37 +165,6 @@ class LogRunTime
 end
 ```
 
-Here you can see a list of all possible callbacks, together with their order of calling:
-
-```ruby
-begin
-  event           before_all_events
-  event           before
-  event           guards
-  transition      guards
-  old_state       before_exit
-  old_state       exit
-                  after_all_transitions
-  transition      after
-  new_state       before_enter
-  new_state       enter
-  ...update state...
-  event           before_success      # if persist successful
-  transition      success             # if persist successful
-  event           success             # if persist successful
-  old_state       after_exit
-  new_state       after_enter
-  event           after
-  event           after_all_events
-rescue
-  event           error
-  event           error_on_all_events
-ensure
-  event           ensure
-  event           ensure_on_all_events
-end
-```
-
 Also, you can pass parameters to events:
 
 ```ruby
@@ -226,6 +195,39 @@ and the target state (the to state), like this:
   def set_process(name)
     logger.info "from #{aasm.from_state} to #{aasm.to_state}"
   end
+```
+
+#### Lifecycle
+
+Here you can see a list of all possible callbacks, together with their order of calling:
+
+```ruby
+begin
+  event           before_all_events
+  event           before
+  event           guards
+  transition      guards
+  old_state       before_exit
+  old_state       exit
+                  after_all_transitions
+  transition      after
+  new_state       before_enter
+  new_state       enter
+  ...update state...
+  event           before_success      # if persist successful
+  transition      success             # if persist successful
+  event           success             # if persist successful
+  old_state       after_exit
+  new_state       after_enter
+  event           after
+  event           after_all_events
+rescue
+  event           error
+  event           error_on_all_events
+ensure
+  event           ensure
+  event           ensure_on_all_events
+end
 ```
 
 #### The current event triggered


### PR DESCRIPTION
I was referencing the AASM lifecycle in a PR I was writing and I wanted to deep link to the order of lifecycle events in the README, but there is no heading for it. This just adds a heading for linking. I also moved it down in the file a bit to keep the rest of the info on callbacks together.