### PR TITLE
Fix "Directly inheriting from ActiveRecord::Migration is not supported" error

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class AASMCreate<%= table_name.camelize %> < ActiveRecord::Migration
+class AASMCreate<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table(:<%= table_name %>) do |t|
       t.string :<%= column_name %>

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class AASMCreate<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class AASMCreate<%= table_name.camelize %> < ActiveRecord::Migration[<%=  ActiveRecord::VERSION::STRING.to_f %>]
   def change
     create_table(:<%= table_name %>) do |t|
       t.string :<%= column_name %>

--- a/lib/generators/active_record/templates/migration_existing.rb
+++ b/lib/generators/active_record/templates/migration_existing.rb
@@ -1,4 +1,4 @@
-class Add<%= column_name.camelize %>To<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class Add<%= column_name.camelize %>To<%= table_name.camelize %> < ActiveRecord::Migration[<%=  ActiveRecord::VERSION::STRING.to_f %>]
   def change
     add_column :<%= table_name %>, :<%= column_name %>, :string
   end

--- a/lib/generators/active_record/templates/migration_existing.rb
+++ b/lib/generators/active_record/templates/migration_existing.rb
@@ -1,4 +1,4 @@
-class Add<%= column_name.camelize %>To<%= table_name.camelize %> < ActiveRecord::Migration
+class Add<%= column_name.camelize %>To<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     add_column :<%= table_name %>, :<%= column_name %>, :string
   end


### PR DESCRIPTION
I think this was introduced in the 5.1 release. I just added the current version to the migration.