### PR TITLE
Sequel transactions

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -1,3 +1,4 @@
+require 'aasm/persistence/orm'
 module AASM
   module Persistence
     module ActiveRecordPersistence
@@ -28,6 +29,7 @@ module AASM
       #
       def self.included(base)
         base.send(:include, AASM::Persistence::Base)
+        base.send(:include, AASM::Persistence::ORM)
         base.send(:include, AASM::Persistence::ActiveRecordPersistence::InstanceMethods)
         base.extend AASM::Persistence::ActiveRecordPersistence::ClassMethods
 
@@ -56,67 +58,45 @@ module AASM
 
       module InstanceMethods
 
-        # Writes <tt>state</tt> to the state column and persists it to the database
-        #
-        #   foo = Foo.find(1)
-        #   foo.aasm.current_state # => :opened
-        #   foo.close!
-        #   foo.aasm.current_state # => :closed
-        #   Foo.find(1).aasm.current_state # => :closed
-        #
-        # NOTE: intended to be called from an event
-        def aasm_write_state(state, name=:default)
-          old_value = read_attribute(self.class.aasm(name).attribute_name)
-          aasm_write_attribute state, name
+        private
 
-          success = if aasm_skipping_validations(name)
-            value = aasm_raw_attribute_value(state, name)
-            aasm_update_column(name, value)
-          else
-            self.save
+        def aasm_raise_invalid_record
+          raise ActiveRecord::RecordInvalid.new(self)
+        end
+
+        def aasm_new_record?
+          new_record?
+        end
+
+        def aasm_save
+          self.save
+        end
+
+        def aasm_update_column(attribute_name, value)
+          self.class.unscoped.where(self.class.primary_key => self.id).update_all(attribute_name => value) == 1
+        end
+
+        def aasm_read_attribute(name)
+          read_attribute(name)
+        end
+
+        def aasm_write_attribute(name, value)
+          write_attribute(name, value)
+        end
+
+        def aasm_transaction(requires_new, requires_lock)
+          self.class.transaction(:requires_new => requires_new) do
+            lock!(requires_lock) if requires_lock
+            yield
           end
-
-          unless success
-            aasm_rollback(name, old_value)
-            raise ActiveRecord::RecordInvalid.new(self) if aasm_whiny_persistence(name)
-          end
-
-          success
-        end
-
-        # Writes <tt>state</tt> to the state column, but does not persist it to the database
-        #
-        #   foo = Foo.find(1)
-        #   foo.aasm.current_state # => :opened
-        #   foo.close
-        #   foo.aasm.current_state # => :closed
-        #   Foo.find(1).aasm.current_state # => :opened
-        #   foo.save
-        #   foo.aasm.current_state # => :closed
-        #   Foo.find(1).aasm.current_state # => :closed
-        #
-        # NOTE: intended to be called from an event
-        def aasm_write_state_without_persistence(state, name=:default)
-          aasm_write_attribute(state, name)
-        end
-
-      private
-
-        def aasm_update_column(name, value)
-          self.class.unscoped.where(self.class.primary_key => self.id).update_all(self.class.aasm(name).attribute_name => value) == 1
-        end
-
-        def aasm_rollback(name, old_value)
-          write_attribute(self.class.aasm(name).attribute_name, old_value)
-          false
         end
 
         def aasm_enum(name=:default)
           case AASM::StateMachineStore.fetch(self.class, true).machine(name).config.enum
-            when false then nil
-            when true then aasm_guess_enum_method(name)
-            when nil then aasm_guess_enum_method(name) if aasm_column_looks_like_enum(name)
-            else AASM::StateMachineStore.fetch(self.class, true).machine(name).config.enum
+          when false then nil
+          when true then aasm_guess_enum_method(name)
+          when nil then aasm_guess_enum_method(name) if aasm_column_looks_like_enum(name)
+          else AASM::StateMachineStore.fetch(self.class, true).machine(name).config.enum
           end
         end
 
@@ -131,23 +111,11 @@ module AASM
           self.class.aasm(name).attribute_name.to_s.pluralize.to_sym
         end
 
-        def aasm_skipping_validations(state_machine_name)
-          AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.skip_validation_on_save
-        end
-
-        def aasm_whiny_persistence(state_machine_name)
-          AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.whiny_persistence
-        end
-
-        def aasm_write_attribute(state, name=:default)
-          write_attribute(self.class.aasm(name).attribute_name, aasm_raw_attribute_value(state, name))
-        end
-
         def aasm_raw_attribute_value(state, name=:default)
           if aasm_enum(name)
             self.class.send(aasm_enum(name))[state]
           else
-            state.to_s
+            super
           end
         end
 
@@ -177,46 +145,6 @@ module AASM
         def aasm_column_is_blank?(state_machine_name)
           attribute_name = self.class.aasm(state_machine_name).attribute_name
           attribute_names.include?(attribute_name.to_s) && send(attribute_name).blank?
-        end
-
-        def aasm_fire_event(state_machine_name, name, options, *args, &block)
-          event = self.class.aasm(state_machine_name).state_machine.events[name]
-
-          if options[:persist]
-            event.fire_callbacks(:before_transaction, self, *args)
-            event.fire_global_callbacks(:before_all_transactions, self, *args)
-          end
-
-          begin
-            success = if options[:persist]
-              self.class.transaction(:requires_new => requires_new?(state_machine_name)) do
-                lock!(requires_lock?(state_machine_name)) if requires_lock?(state_machine_name)
-                super
-              end
-            else
-              super
-            end
-
-            if options[:persist] && success
-              event.fire_callbacks(:after_commit, self, *args)
-              event.fire_global_callbacks(:after_all_commits, self, *args)
-            end
-          ensure
-            if options[:persist]
-              event.fire_callbacks(:after_transaction, self, *args)
-              event.fire_global_callbacks(:after_all_transactions, self, *args)
-            end
-          end
-
-          success
-        end
-
-        def requires_new?(state_machine_name)
-          AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.requires_new_transaction
-        end
-
-        def requires_lock?(state_machine_name)
-          AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.requires_lock
         end
 
         def aasm_validate_states

--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -64,10 +64,6 @@ module AASM
           raise ActiveRecord::RecordInvalid.new(self)
         end
 
-        def aasm_new_record?
-          new_record?
-        end
-
         def aasm_save
           self.save
         end

--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -34,11 +34,15 @@ module AASM
       # This allows for nil aasm states - be sure to add validation to your model
       def aasm_read_state(name=:default)
         state = send(self.class.aasm(name).attribute_name)
-        if new_record?
-          state.blank? ? aasm(name).determine_state_name(self.class.aasm(name).initial_state) : state.to_sym
+        if state.blank?
+          aasm_new_record? ? aasm(name).determine_state_name(self.class.aasm(name).initial_state) : nil
         else
-          state.blank? ? nil : state.to_sym
+          state.to_sym
         end
+      end
+
+      def aasm_new_record?
+        raise("Define #aasm_new_record? in the AASM Persistence class.")
       end
 
       module ClassMethods

--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -42,7 +42,7 @@ module AASM
       end
 
       def aasm_new_record?
-        raise("Define #aasm_new_record? in the AASM Persistence class.")
+        new_record?
       end
 
       module ClassMethods

--- a/lib/aasm/persistence/mongoid_persistence.rb
+++ b/lib/aasm/persistence/mongoid_persistence.rb
@@ -1,3 +1,4 @@
+require 'aasm/persistence/orm'
 module AASM
   module Persistence
     module MongoidPersistence
@@ -30,6 +31,7 @@ module AASM
       #
       def self.included(base)
         base.send(:include, AASM::Persistence::Base)
+        base.send(:include, AASM::Persistence::ORM)
         base.send(:include, AASM::Persistence::MongoidPersistence::InstanceMethods)
         base.extend AASM::Persistence::MongoidPersistence::ClassMethods
 
@@ -50,55 +52,25 @@ module AASM
 
       module InstanceMethods
 
-        # Writes <tt>state</tt> to the state field and persists it to the database
-        #
-        #   foo = Foo.find(1)
-        #   foo.aasm.current_state # => :opened
-        #   foo.close!
-        #   foo.aasm.current_state # => :closed
-        #   Foo.find(1).aasm.current_state # => :closed
-        #
-        # NOTE: intended to be called from an event
-        def aasm_write_state(state, name=:default)
-          old_value = read_attribute(self.class.aasm(name).attribute_name)
-          aasm_write_attribute(state, name)
+        private
 
-          success = if aasm_skipping_validations(name)
-                      value = aasm_raw_attribute_value(state, name)
-                      aasm_update_column(name, value)
-                    else
-                      self.save
-                    end
-
-          unless success
-            aasm_rollback(name, old_value)
-            raise Mongoid::Errors::Validations.new(self) if aasm_whiny_persistence(name)
-          end
-
-          success
+        def aasm_save
+          self.save
         end
 
-        # Writes <tt>state</tt> to the state field, but does not persist it to the database
-        #
-        #   foo = Foo.find(1)
-        #   foo.aasm.current_state # => :opened
-        #   foo.close
-        #   foo.aasm.current_state # => :closed
-        #   Foo.find(1).aasm.current_state # => :opened
-        #   foo.save
-        #   foo.aasm.current_state # => :closed
-        #   Foo.find(1).aasm.current_state # => :closed
-        #
-        # NOTE: intended to be called from an event
-        def aasm_write_state_without_persistence(state, name=:default)
-          aasm_write_attribute(state, name)
+        def aasm_new_record?
+          new_record?
         end
 
-      private
+        def aasm_raise_invalid_record
+          raise Mongoid::Errors::Validations.new(self)
+        end
 
-        def aasm_update_column(name, value)
-          attribute_name = self.class.aasm(name).attribute_name
+        def aasm_supports_transactions?
+          false
+        end
 
+        def aasm_update_column(attribute_name, value)
           if Mongoid::VERSION.to_f >= 4
             set(Hash[attribute_name, value])
           else
@@ -108,25 +80,12 @@ module AASM
           true
         end
 
-        def aasm_rollback(name, old_value)
-          write_attribute(self.class.aasm(name).attribute_name, old_value)
-          false
+        def aasm_read_attribute(name)
+          read_attribute(name)
         end
 
-        def aasm_skipping_validations(state_machine_name)
-          AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.skip_validation_on_save
-        end
-
-        def aasm_whiny_persistence(state_machine_name)
-          AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.whiny_persistence
-        end
-
-        def aasm_write_attribute(state, name=:default)
-          write_attribute(self.class.aasm(name).attribute_name, aasm_raw_attribute_value(state, name))
-        end
-
-        def aasm_raw_attribute_value(state, _name=:default)
-          state.to_s
+        def aasm_write_attribute(name, value)
+          write_attribute(name, value)
         end
 
         # Ensures that if the aasm_state column is nil and the record is new

--- a/lib/aasm/persistence/mongoid_persistence.rb
+++ b/lib/aasm/persistence/mongoid_persistence.rb
@@ -58,10 +58,6 @@ module AASM
           self.save
         end
 
-        def aasm_new_record?
-          new_record?
-        end
-
         def aasm_raise_invalid_record
           raise Mongoid::Errors::Validations.new(self)
         end

--- a/lib/aasm/persistence/orm.rb
+++ b/lib/aasm/persistence/orm.rb
@@ -1,0 +1,142 @@
+module AASM
+  module Persistence
+    # This module adds transactional support for any database that supports it.
+    # This includes rollback capability and rollback/commit callbacks.
+    module ORM
+
+      # Writes <tt>state</tt> to the state column and persists it to the database
+      #
+      #   foo = Foo.find(1)
+      #   foo.aasm.current_state # => :opened
+      #   foo.close!
+      #   foo.aasm.current_state # => :closed
+      #   Foo.find(1).aasm.current_state # => :closed
+      #
+      # NOTE: intended to be called from an event
+      def aasm_write_state(state, name=:default)
+        attribute_name = self.class.aasm(name).attribute_name
+        old_value = aasm_read_attribute(attribute_name)
+        aasm_write_state_attribute state, name
+
+        success = if aasm_skipping_validations(name)
+          aasm_update_column(attribute_name, aasm_raw_attribute_value(state, name))
+        else
+          aasm_save
+        end
+
+        unless success
+          aasm_rollback(name, old_value)
+          aasm_raise_invalid_record if aasm_whiny_persistence(name)
+        end
+
+        success
+      end
+
+      # Writes <tt>state</tt> to the state field, but does not persist it to the database
+      #
+      #   foo = Foo.find(1)
+      #   foo.aasm.current_state # => :opened
+      #   foo.close
+      #   foo.aasm.current_state # => :closed
+      #   Foo.find(1).aasm.current_state # => :opened
+      #   foo.save
+      #   foo.aasm.current_state # => :closed
+      #   Foo.find(1).aasm.current_state # => :closed
+      #
+      # NOTE: intended to be called from an event
+      def aasm_write_state_without_persistence(state, name=:default)
+        aasm_write_state_attribute(state, name)
+      end
+
+      private
+
+      # Save the record and return true if it succeeded/false otherwise.
+      def aasm_save
+        raise("Define #aasm_save_without_error in the AASM Persistence class.")
+      end
+
+      def aasm_raise_invalid_record
+        raise("Define #aasm_raise_invalid_record in the AASM Persistence class.")
+      end
+
+      # Update only the column without running validations.
+      def aasm_update_column(attribute_name, value)
+        raise("Define #aasm_update_column in the AASM Persistence class.")
+      end
+
+      def aasm_read_attribute(name)
+        raise("Define #aasm_read_attribute the AASM Persistence class.")
+      end
+
+      def aasm_write_attribute(name, value)
+        raise("Define #aasm_write_attribute in the AASM Persistence class.")
+      end
+
+      # Returns true or false if transaction completed successfully.
+      def aasm_transaction(requires_new, requires_lock)
+        raise("Define #aasm_transaction the AASM Persistence class.")
+      end
+
+      def aasm_supports_transactions?
+        true
+      end
+
+      def aasm_write_state_attribute(state, name=:default)
+        aasm_write_attribute(self.class.aasm(name).attribute_name, aasm_raw_attribute_value(state, name))
+      end
+
+      def aasm_raw_attribute_value(state, _name=:default)
+        state.to_s
+      end
+
+      def aasm_rollback(name, old_value)
+        aasm_write_attribute(self.class.aasm(name).attribute_name, old_value)
+        false
+      end
+
+      def aasm_whiny_persistence(state_machine_name)
+        AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.whiny_persistence
+      end
+
+      def aasm_skipping_validations(state_machine_name)
+        AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.skip_validation_on_save
+      end
+
+      def requires_new?(state_machine_name)
+        AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.requires_new_transaction
+      end
+
+      def requires_lock?(state_machine_name)
+        AASM::StateMachineStore.fetch(self.class, true).machine(state_machine_name).config.requires_lock
+      end
+
+      # Returns true if event was fired successfully and transaction completed.
+      def aasm_fire_event(state_machine_name, name, options, *args, &block)
+        if aasm_supports_transactions? && options[:persist]
+          event = self.class.aasm(state_machine_name).state_machine.events[name]
+          event.fire_callbacks(:before_transaction, self, *args)
+          event.fire_global_callbacks(:before_all_transactions, self, *args)
+
+          begin
+            success = aasm_transaction(requires_new?(state_machine_name), requires_lock?(state_machine_name)) do
+              super
+            end
+
+            if success
+              event.fire_callbacks(:after_commit, self, *args)
+              event.fire_global_callbacks(:after_all_commits, self, *args)
+            end
+
+            success
+          ensure
+            event.fire_callbacks(:after_transaction, self, *args)
+            event.fire_global_callbacks(:after_all_transactions, self, *args)
+          end
+        else
+          super
+        end
+      end
+
+    end # Transactional
+  end # Persistence
+end # AASM

--- a/lib/aasm/persistence/sequel_persistence.rb
+++ b/lib/aasm/persistence/sequel_persistence.rb
@@ -1,8 +1,10 @@
+require 'aasm/persistence/orm'
 module AASM
   module Persistence
     module SequelPersistence
       def self.included(base)
         base.send(:include, AASM::Persistence::Base)
+        base.send(:include, AASM::Persistence::ORM)
         base.send(:include, AASM::Persistence::SequelPersistence::InstanceMethods)
       end
 
@@ -17,40 +19,40 @@ module AASM
           super
         end
 
-        # Returns the value of the aasm.attribute_name - called from <tt>aasm.current_state</tt>
-        #
-        # If it's a new record, and the aasm state column is blank it returns the initial state
-        #
-        #   class Foo < Sequel::Model
-        #     include AASM
-        #     aasm :column => :status do
-        #       state :opened
-        #       state :closed
-        #     end
-        #   end
-        #
-        #   foo = Foo.new
-        #   foo.current_state # => :opened
-        #   foo.close
-        #   foo.current_state # => :closed
-        #
-        #   foo = Foo[1]
-        #   foo.current_state # => :opened
-        #   foo.aasm_state = nil
-        #   foo.current_state # => nil
-        #
-        # NOTE: intended to be called from an event
-        #
-        # This allows for nil aasm states - be sure to add validation to your model
-        def aasm_read_state(name=:default)
-          state = send(self.class.aasm(name).attribute_name)
-          if new? && state.to_s.strip.empty?
-            aasm(name).determine_state_name(self.class.aasm(name).initial_state)
-          elsif state.nil?
-            nil
-          else
-            state.to_sym
+        def aasm_raise_invalid_record
+          raise Sequel::ValidationFailed.new(self)
+        end
+
+        def aasm_new_record?
+          new?
+        end
+
+        # Returns nil if fails silently
+        # http://sequel.jeremyevans.net/rdoc/classes/Sequel/Model/InstanceMethods.html#method-i-save
+        def aasm_save
+          !save(raise_on_failure: false).nil?
+        end
+
+        def aasm_read_attribute(name)
+          send(name)
+        end
+
+        def aasm_write_attribute(name, value)
+          send("#{name}=", value)
+        end
+
+        def aasm_transaction(requires_new, requires_lock)
+          self.class.db.transaction(savepoint: requires_new) do
+            if requires_lock
+              # http://sequel.jeremyevans.net/rdoc/classes/Sequel/Model/InstanceMethods.html#method-i-lock-21
+              requires_lock.is_a?(String) ? lock!(requires_lock) : lock!
+            end
+            yield
           end
+        end
+
+        def aasm_update_column(attribute_name, value)
+          this.update(attribute_name => value)
         end
 
         # Ensures that if the aasm_state column is nil and the record is new
@@ -72,39 +74,10 @@ module AASM
           AASM::StateMachineStore.fetch(self.class, true).machine_names.each do |state_machine_name|
             aasm(state_machine_name).enter_initial_state if
               (new? || values.key?(self.class.aasm(state_machine_name).attribute_name)) &&
-              send(self.class.aasm(state_machine_name).attribute_name).to_s.strip.empty?
+                send(self.class.aasm(state_machine_name).attribute_name).to_s.strip.empty?
           end
         end
 
-        # Writes <tt>state</tt> to the state column and persists it to the database
-        #
-        #   foo = Foo[1]
-        #   foo.aasm.current_state # => :opened
-        #   foo.close!
-        #   foo.aasm.current_state # => :closed
-        #   Foo[1].aasm.current_state # => :closed
-        #
-        # NOTE: intended to be called from an event
-        def aasm_write_state state, name=:default
-          aasm_column = self.class.aasm(name).attribute_name
-          update_fields({aasm_column => state.to_s}, [aasm_column], missing: :skip)
-        end
-
-        # Writes <tt>state</tt> to the state column, but does not persist it to the database
-        #
-        #   foo = Foo[1]
-        #   foo.aasm.current_state # => :opened
-        #   foo.close
-        #   foo.aasm.current_state # => :closed
-        #   Foo[1].aasm.current_state # => :opened
-        #   foo.save
-        #   foo.aasm.current_state # => :closed
-        #   Foo[1].aasm.current_state # => :closed
-        #
-        # NOTE: intended to be called from an event
-        def aasm_write_state_without_persistence state, name=:default
-          send("#{self.class.aasm(name).attribute_name}=", state.to_s)
-        end
       end
     end
   end

--- a/spec/models/sequel/complex_sequel_example.rb
+++ b/spec/models/sequel/complex_sequel_example.rb
@@ -1,4 +1,4 @@
-db = Sequel.connect(SEQUEL_DB)
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
 
 # if you want to see the statements while running the spec enable the following line
 # db.loggers << Logger.new($stderr)
@@ -8,8 +8,8 @@ db.create_table(:complex_sequel_examples) do
   String :right
 end
 
-class ComplexSequelExample < Sequel::Model(db)
-  set_dataset(:complex_sequel_examples)
+module Sequel
+class ComplexExample < Sequel::Model(:complex_sequel_examples)
 
   include AASM
 
@@ -42,4 +42,5 @@ class ComplexSequelExample < Sequel::Model(db)
     end
   end
 
+end
 end

--- a/spec/models/sequel/invalid_persistor.rb
+++ b/spec/models/sequel/invalid_persistor.rb
@@ -1,0 +1,52 @@
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
+
+[:invalid_persistors, :multiple_invalid_persistors].each do |table_name|
+  db.create_table(table_name) do
+    primary_key :id
+    String "name"
+    String "status"
+  end
+end
+
+module Sequel
+  class InvalidPersistor < Sequel::Model(:invalid_persistors)
+    plugin :validation_helpers
+
+    include AASM
+    aasm :column => :status, :skip_validation_on_save => true do
+      state :sleeping, :initial => true
+      state :running
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+      event :sleep do
+        transitions :to => :sleeping, :from => :running
+      end
+    end
+
+    def validate
+      super
+      validates_presence :name
+    end
+  end
+
+  class MultipleInvalidPersistor < Sequel::Model(:multiple_invalid_persistors)
+    plugin :validation_helpers
+
+    include AASM
+    aasm :left, :column => :status, :skip_validation_on_save => true do
+      state :sleeping, :initial => true
+      state :running
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+      event :sleep do
+        transitions :to => :sleeping, :from => :running
+      end
+    end
+    def validate
+      super
+      validates_presence :name
+    end
+  end
+end

--- a/spec/models/sequel/sequel_multiple.rb
+++ b/spec/models/sequel/sequel_multiple.rb
@@ -1,4 +1,4 @@
-db = Sequel.connect(SEQUEL_DB)
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
 
 # if you want to see the statements while running the spec enable the following line
 # db.loggers << Logger.new($stderr)
@@ -6,20 +6,20 @@ db.create_table(:multiples) do
   primary_key :id
   String :status
 end
+module Sequel
+  class Multiple < Sequel::Model(:multiples)
+    include AASM
 
-class SequelMultiple < Sequel::Model(db)
-  set_dataset(:multiples)
-  include AASM
+    attr_accessor :default
 
-  attr_accessor :default
-
-  aasm :left, :column => :status
-  aasm :left do
-    state :alpha, :initial => true
-    state :beta
-    state :gamma
-    event :release do
-      transitions :from => [:alpha, :beta, :gamma], :to => :beta
+    aasm :left, :column => :status
+    aasm :left do
+      state :alpha, :initial => true
+      state :beta
+      state :gamma
+      event :release do
+        transitions :from => [:alpha, :beta, :gamma], :to => :beta
+      end
     end
   end
 end

--- a/spec/models/sequel/sequel_simple.rb
+++ b/spec/models/sequel/sequel_simple.rb
@@ -1,4 +1,4 @@
-db = Sequel.connect(SEQUEL_DB)
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
 
 # if you want to see the statements while running the spec enable the following line
 # db.loggers << Logger.new($stderr)
@@ -7,19 +7,20 @@ db.create_table(:simples) do
   String :status
 end
 
-class SequelSimple < Sequel::Model(db)
-  set_dataset(:simples)
-  include AASM
+module Sequel
+  class Simple < Sequel::Model(:simples)
+    include AASM
 
-  attr_accessor :default
+    attr_accessor :default
 
-  aasm :column => :status
-  aasm do
-    state :alpha, :initial => true
-    state :beta
-    state :gamma
-    event :release do
-      transitions :from => [:alpha, :beta, :gamma], :to => :beta
+    aasm :column => :status
+    aasm do
+      state :alpha, :initial => true
+      state :beta
+      state :gamma
+      event :release do
+        transitions :from => [:alpha, :beta, :gamma], :to => :beta
+      end
     end
   end
 end

--- a/spec/models/sequel/silent_persistor.rb
+++ b/spec/models/sequel/silent_persistor.rb
@@ -1,0 +1,50 @@
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
+
+[:silent_persistors, :multiple_silent_persistors].each do |t|
+  db.create_table(t) do
+    primary_key :id
+    String "name"
+    String "status"
+  end
+end
+
+module Sequel
+  class SilentPersistor < Sequel::Model(:silent_persistors)
+    plugin :validation_helpers
+
+    include AASM
+    aasm :column => :status, :whiny_persistence => false do
+      state :sleeping, :initial => true
+      state :running
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+      event :sleep do
+        transitions :to => :sleeping, :from => :running
+      end
+    end
+    def validate
+      validates_presence :name
+    end
+  end
+
+  class MultipleSilentPersistor< Sequel::Model(:multiple_silent_persistors)
+    plugin :validation_helpers
+
+    include AASM
+    aasm :left, :column => :status, :whiny_persistence => false do
+      state :sleeping, :initial => true
+      state :running
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+      event :sleep do
+        transitions :to => :sleeping, :from => :running
+      end
+    end
+
+    def validate
+      validates_presence :name
+    end
+  end
+end

--- a/spec/models/sequel/transactor.rb
+++ b/spec/models/sequel/transactor.rb
@@ -1,0 +1,112 @@
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
+
+[:transactors, :no_lock_transactors, :lock_transactors, :lock_no_wait_transactors, :multiple_transactors].each do |table_name|
+  db.create_table(table_name) do
+    primary_key :id
+    String "name"
+    String "status"
+    Fixnum "worker_id"
+  end
+end
+
+module Sequel
+  class Transactor < Sequel::Model(:transactors)
+
+    many_to_one :worker, class: 'Sequel::Worker'
+
+    include AASM
+    aasm :column => :status do
+      state :sleeping, :initial => true
+      state :running, :before_enter => :start_worker, :after_enter => :fail
+
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+    end
+
+    private
+
+    def start_worker
+      worker.update(status: 'running')
+    end
+
+    def fail
+      raise StandardError.new('failed on purpose')
+    end
+
+  end
+
+  class NoLockTransactor < Sequel::Model(:no_lock_transactors)
+
+    many_to_one :worker, class: 'Sequel::Worker'
+
+    include AASM
+
+    aasm :column => :status do
+      state :sleeping, :initial => true
+      state :running
+
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+    end
+  end
+
+  class LockTransactor < Sequel::Model(:lock_transactors)
+
+    many_to_one :worker, class: 'Sequel::Worker'
+
+    include AASM
+
+    aasm :column => :status, requires_lock: true do
+      state :sleeping, :initial => true
+      state :running
+
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+    end
+  end
+
+  class LockNoWaitTransactor < Sequel::Model(:lock_no_wait_transactors)
+
+    many_to_one :worker, class: 'Sequel::Worker'
+
+    include AASM
+
+    aasm :column => :status, requires_lock: 'FOR UPDATE NOWAIT' do
+      state :sleeping, :initial => true
+      state :running
+
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+    end
+  end
+
+  class MultipleTransactor < Sequel::Model(:multiple_transactors)
+
+    many_to_one :worker, class: 'Sequel::Worker'
+
+    include AASM
+    aasm :left, :column => :status do
+      state :sleeping, :initial => true
+      state :running, :before_enter => :start_worker, :after_enter => :fail
+
+      event :run do
+        transitions :to => :running, :from => :sleeping
+      end
+    end
+
+    private
+
+    def start_worker
+      worker.update(:status, 'running')
+    end
+
+    def fail
+      raise StandardError.new('failed on purpose')
+    end
+
+  end
+end

--- a/spec/models/sequel/validator.rb
+++ b/spec/models/sequel/validator.rb
@@ -1,0 +1,93 @@
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
+
+db.create_table(:validators) do
+  primary_key :id
+  String "name"
+  String "status"
+  Fixnum "worker_id"
+end
+
+module Sequel
+  class Validator < Sequel::Model(:validators)
+    plugin :validation_helpers
+
+    attr_accessor :after_all_transactions_performed,
+      :after_transaction_performed_on_fail,
+      :after_transaction_performed_on_run,
+      :before_all_transactions_performed,
+      :before_transaction_performed_on_fail,
+      :before_transaction_performed_on_run,
+      :invalid
+
+    def validate
+      super
+      errors.add(:validator, "invalid") if invalid
+      validates_presence :name
+    end
+
+    include AASM
+
+    aasm :column => :status, :whiny_persistence => true do
+      before_all_transactions :before_all_transactions
+      after_all_transactions  :after_all_transactions
+
+      state :sleeping, :initial => true
+      state :running
+      state :failed, :after_enter => :fail
+
+      event :run, :after_commit => :change_name! do
+        after_transaction do
+          @after_transaction_performed_on_run = true
+        end
+
+        before_transaction do
+          @before_transaction_performed_on_run = true
+        end
+
+        transitions :to => :running, :from => :sleeping
+      end
+
+      event :sleep do
+        after_commit do |name|
+          change_name_on_sleep name
+        end
+        transitions :to => :sleeping, :from => :running
+      end
+
+      event :fail do
+        after_transaction do
+          @after_transaction_performed_on_fail = true
+        end
+
+        before_transaction do
+          @before_transaction_performed_on_fail = true
+        end
+
+        transitions :to => :failed, :from => [:sleeping, :running]
+      end
+    end
+
+    def change_name!
+      self.name = "name changed"
+      save(raise_on_failure: true)
+    end
+
+    def change_name_on_sleep name
+      self.name = name
+      save(raise_on_failure: true)
+    end
+
+    def fail
+      raise StandardError.new('failed on purpose')
+    end
+
+    def after_all_transactions
+      @after_all_transactions_performed = true
+    end
+
+    def before_all_transactions
+      @before_all_transactions_performed = true
+    end
+  end
+
+end

--- a/spec/models/sequel/worker.rb
+++ b/spec/models/sequel/worker.rb
@@ -1,0 +1,12 @@
+db = Sequel::DATABASES.first || Sequel.connect(SEQUEL_DB)
+
+db.create_table(:workers) do
+  primary_key :id
+  String "name"
+  String "status"
+end
+
+module Sequel
+  class Worker < Sequel::Model(:workers)
+  end
+end

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -139,7 +139,7 @@ if defined?(ActiveRecord)
 
       before :each do
         allow(gate).to receive(:aasm_enum).and_return(enum_name)
-        allow(gate).to receive(:aasm_write_attribute)
+        allow(gate).to receive(:aasm_write_state_attribute)
         allow(gate).to receive(:write_attribute)
 
         allow(MultipleGate).to receive(enum_name).and_return(enum)
@@ -173,7 +173,7 @@ if defined?(ActiveRecord)
 
             gate.aasm_write_state state_sym, :left
 
-            expect(gate).to have_received(:aasm_write_attribute).with(state_sym, :left)
+            expect(gate).to have_received(:aasm_write_state_attribute).with(state_sym, :left)
             expect(gate).to_not have_received :write_attribute
           end
         end
@@ -183,7 +183,7 @@ if defined?(ActiveRecord)
         it "delegates state update to the helper method" do
           gate.aasm_write_state_without_persistence state_sym, :left
 
-          expect(gate).to have_received(:aasm_write_attribute).with(state_sym, :left)
+          expect(gate).to have_received(:aasm_write_state_attribute).with(state_sym, :left)
           expect(gate).to_not have_received :write_attribute
         end
       end
@@ -219,7 +219,7 @@ if defined?(ActiveRecord)
         allow(gate).to receive(:write_attribute)
         allow(gate).to receive(:aasm_raw_attribute_value).and_return(value)
 
-        gate.send(:aasm_write_attribute, sym, :left)
+        gate.send(:aasm_write_state_attribute, sym, :left)
       end
 
       it "generates attribute value using a helper method" do

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -139,7 +139,7 @@ if defined?(ActiveRecord)
 
       before :each do
         allow(gate).to receive(:aasm_enum).and_return(enum_name)
-        allow(gate).to receive(:aasm_write_attribute)
+        allow(gate).to receive(:aasm_write_state_attribute)
         allow(gate).to receive(:write_attribute)
 
         allow(Gate).to receive(enum_name).and_return(enum)
@@ -191,7 +191,7 @@ if defined?(ActiveRecord)
 
             gate.aasm_write_state state_sym
 
-            expect(gate).to have_received(:aasm_write_attribute).with(state_sym, :default)
+            expect(gate).to have_received(:aasm_write_state_attribute).with(state_sym, :default)
             expect(gate).to_not have_received :write_attribute
           end
         end
@@ -201,7 +201,7 @@ if defined?(ActiveRecord)
         it "delegates state update to the helper method" do
           gate.aasm_write_state_without_persistence state_sym
 
-          expect(gate).to have_received(:aasm_write_attribute).with(state_sym, :default)
+          expect(gate).to have_received(:aasm_write_state_attribute).with(state_sym, :default)
           expect(gate).to_not have_received :write_attribute
         end
       end
@@ -237,7 +237,7 @@ if defined?(ActiveRecord)
         allow(gate).to receive(:write_attribute)
         allow(gate).to receive(:aasm_raw_attribute_value).and_return(value)
 
-        gate.send(:aasm_write_attribute, sym)
+        gate.send(:aasm_write_state_attribute, sym)
       end
 
       it "generates attribute value using a helper method" do

--- a/spec/unit/persistence/sequel_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/sequel_persistence_multiple_spec.rb
@@ -8,7 +8,7 @@ if defined?(Sequel)
     end
 
     before(:all) do
-      @model = SequelMultiple
+      @model = Sequel::Multiple
     end
 
     describe "instance methods" do
@@ -93,7 +93,7 @@ if defined?(Sequel)
 
     describe "complex example" do
       it "works" do
-        record = ComplexSequelExample.new
+        record = Sequel::ComplexExample.new
         expect(record.aasm(:left).current_state).to eql :one
         expect(record.left).to be_nil
         expect(record.aasm(:right).current_state).to eql :alpha

--- a/spec/unit/persistence/sequel_persistence_spec.rb
+++ b/spec/unit/persistence/sequel_persistence_spec.rb
@@ -1,14 +1,13 @@
 require 'spec_helper'
-
 if defined?(Sequel)
   describe 'sequel' do
-
+  
     Dir[File.dirname(__FILE__) + "/../../models/sequel/*.rb"].sort.each do |f|
       require File.expand_path(f)
     end
 
     before(:all) do
-      @model = SequelSimple
+      @model = Sequel::Simple
     end
 
     describe "instance methods" do
@@ -88,6 +87,280 @@ if defined?(Sequel)
 
         expect(@model.new(:default => :beta).aasm.current_state).to eq(:beta)
         expect(@model.new(:default => :gamma).aasm.current_state).to eq(:gamma)
+      end
+    end
+
+    describe 'transitions with persistence' do
+
+      it "should work for valid models" do
+        valid_object = Sequel::Validator.create(:name => 'name')
+        expect(valid_object).to be_sleeping
+        valid_object.status = :running
+        expect(valid_object).to be_running
+      end
+
+      it 'should not store states for invalid models' do
+        validator = Sequel::Validator.create(:name => 'name')
+        expect(validator).to be_valid
+        expect(validator).to be_sleeping
+
+        validator.name = nil
+        expect(validator).not_to be_valid
+        expect { validator.run! }.to raise_error(Sequel::ValidationFailed)
+        expect(validator).to be_sleeping
+
+        validator.reload
+        expect(validator).not_to be_running
+        expect(validator).to be_sleeping
+
+        validator.name = 'another name'
+        expect(validator).to be_valid
+        expect(validator.run!).to be_truthy
+        expect(validator).to be_running
+
+        validator.reload
+        expect(validator).to be_running
+        expect(validator).not_to be_sleeping
+      end
+
+      it 'should not store states for invalid models silently if configured' do
+        validator = Sequel::SilentPersistor.create(:name => 'name')
+        expect(validator).to be_valid
+        expect(validator).to be_sleeping
+
+        validator.name = nil
+        expect(validator).not_to be_valid
+        expect(validator.run!).to be_falsey
+        expect(validator).to be_sleeping
+
+        validator.reload
+        expect(validator).not_to be_running
+        expect(validator).to be_sleeping
+
+        validator.name = 'another name'
+        expect(validator).to be_valid
+        expect(validator.run!).to be_truthy
+        expect(validator).to be_running
+
+        validator.reload
+        expect(validator).to be_running
+        expect(validator).not_to be_sleeping
+      end
+
+      it 'should store states for invalid models if configured' do
+        persistor = Sequel::InvalidPersistor.create(:name => 'name')
+        expect(persistor).to be_valid
+        expect(persistor).to be_sleeping
+
+        persistor.name = nil
+        expect(persistor).not_to be_valid
+        expect(persistor.run!).to be_truthy
+        expect(persistor).to be_running
+
+        persistor = Sequel::InvalidPersistor[persistor.id]
+        persistor.valid?
+        expect(persistor).to be_valid
+        expect(persistor).to be_running
+        expect(persistor).not_to be_sleeping
+
+        persistor.reload
+        expect(persistor).to be_running
+        expect(persistor).not_to be_sleeping
+      end
+
+      describe 'pessimistic locking' do
+        let(:worker) { Sequel::Worker.create(:name => 'worker', :status => 'sleeping') }
+
+        subject { transactor.run! }
+
+        context 'no lock' do
+          let(:transactor) { Sequel::NoLockTransactor.create(:name => 'no_lock_transactor', :worker => worker) }
+
+          it 'should not invoke lock!' do
+            expect(transactor).to_not receive(:lock!)
+            subject
+          end
+        end
+
+        context 'a default lock' do
+          let(:transactor) { Sequel::LockTransactor.create(:name => 'lock_transactor', :worker => worker) }
+
+          it 'should invoke lock!' do
+            expect(transactor).to receive(:lock!).and_call_original
+            subject
+          end
+        end
+
+        context 'a FOR UPDATE NOWAIT lock' do
+          let(:transactor) { Sequel::LockNoWaitTransactor.create(:name => 'lock_no_wait_transactor', :worker => worker) }
+
+          it 'should invoke lock! with FOR UPDATE NOWAIT' do
+            # TODO: With and_call_original, get an error with syntax, should look into it.
+            expect(transactor).to receive(:lock!).with('FOR UPDATE NOWAIT')# .and_call_original
+            subject
+          end
+        end
+      end
+
+      describe 'transactions' do
+        let(:worker) { Sequel::Worker.create(:name => 'worker', :status => 'sleeping') }
+        let(:transactor) { Sequel::Transactor.create(:name => 'transactor', :worker => worker) }
+
+        it 'should rollback all changes' do
+          expect(transactor).to be_sleeping
+          expect(worker.status).to eq('sleeping')
+
+          expect {transactor.run!}.to raise_error(StandardError, 'failed on purpose')
+          expect(transactor).to be_running
+          expect(worker.reload.status).to eq('sleeping')
+        end
+
+        context "nested transactions" do
+          it "should rollback all changes in nested transaction" do
+            expect(transactor).to be_sleeping
+            expect(worker.status).to eq('sleeping')
+
+            Sequel::Worker.db.transaction do
+              expect { transactor.run! }.to raise_error(StandardError, 'failed on purpose')
+            end
+
+            expect(transactor).to be_running
+            expect(worker.reload.status).to eq('sleeping')
+          end
+
+          it "should only rollback changes in the main transaction not the nested one" do
+            # change configuration to not require new transaction
+            AASM::StateMachineStore[Sequel::Transactor][:default].config.requires_new_transaction = false
+
+            expect(transactor).to be_sleeping
+            expect(worker.status).to eq('sleeping')
+            Sequel::Worker.db.transaction do
+              expect { transactor.run! }.to raise_error(StandardError, 'failed on purpose')
+            end
+            expect(transactor).to be_running
+            expect(worker.reload.status).to eq('running')
+          end
+        end
+
+        describe "after_commit callback" do
+          it "should fire :after_commit if transaction was successful" do
+            validator = Sequel::Validator.create(:name => 'name')
+            expect(validator).to be_sleeping
+
+            validator.run!
+            expect(validator).to be_running
+            expect(validator.name).to eq("name changed")
+
+            validator.sleep!("sleeper")
+            expect(validator).to be_sleeping
+            expect(validator.name).to eq("sleeper")
+          end
+
+          it "should not fire :after_commit if transaction failed" do
+            validator = Sequel::Validator.create(:name => 'name')
+            expect { validator.fail! }.to raise_error(StandardError, 'failed on purpose')
+            expect(validator.name).to eq("name")
+          end
+
+          it "should not fire :after_commit if validation failed when saving object" do
+            validator = Sequel::Validator.create(:name => 'name')
+            validator.invalid = true
+            expect { validator.run! }.to raise_error(Sequel::ValidationFailed, 'validator invalid')
+            expect(validator).to be_sleeping
+            expect(validator.name).to eq("name")
+          end
+
+          it "should not fire if not saving" do
+            validator = Sequel::Validator.create(:name => 'name')
+            expect(validator).to be_sleeping
+            validator.run
+            expect(validator).to be_running
+            expect(validator.name).to eq("name")
+          end
+        end
+
+        describe 'before and after transaction callbacks' do
+          [:after, :before].each do |event_type|
+            describe "#{event_type}_transaction callback" do
+              it "should fire :#{event_type}_transaction if transaction was successful" do
+                validator = Sequel::Validator.create(:name => 'name')
+                expect(validator).to be_sleeping
+
+                expect { validator.run! }.to change { validator.send("#{event_type}_transaction_performed_on_run") }.from(nil).to(true)
+                expect(validator).to be_running
+              end
+
+              it "should fire :#{event_type}_transaction if transaction failed" do
+                validator = Sequel::Validator.create(:name => 'name')
+                expect do
+                  begin
+                    validator.fail!
+                  rescue => ignored
+                  end
+                end.to change { validator.send("#{event_type}_transaction_performed_on_fail") }.from(nil).to(true)
+                expect(validator).to_not be_running
+              end
+
+              it "should not fire :#{event_type}_transaction if not saving" do
+                validator = Sequel::Validator.create(:name => 'name')
+                expect(validator).to be_sleeping
+                expect { validator.run }.to_not change { validator.send("#{event_type}_transaction_performed_on_run") }
+                expect(validator).to be_running
+                expect(validator.name).to eq("name")
+              end
+            end
+          end
+        end
+
+        describe 'before and after all transactions callbacks' do
+          [:after, :before].each do |event_type|
+            describe "#{event_type}_all_transactions callback" do
+              it "should fire :#{event_type}_all_transactions if transaction was successful" do
+                validator = Sequel::Validator.create(:name => 'name')
+                expect(validator).to be_sleeping
+
+                expect { validator.run! }.to change { validator.send("#{event_type}_all_transactions_performed") }.from(nil).to(true)
+                expect(validator).to be_running
+              end
+
+              it "should fire :#{event_type}_all_transactions if transaction failed" do
+                validator = Sequel::Validator.create(:name => 'name')
+                expect do
+                  begin
+                    validator.fail!
+                  rescue => ignored
+                  end
+                end.to change { validator.send("#{event_type}_all_transactions_performed") }.from(nil).to(true)
+                expect(validator).to_not be_running
+              end
+
+              it "should not fire :#{event_type}_all_transactions if not saving" do
+                validator = Sequel::Validator.create(:name => 'name')
+                expect(validator).to be_sleeping
+                expect { validator.run }.to_not change { validator.send("#{event_type}_all_transactions_performed") }
+                expect(validator).to be_running
+                expect(validator.name).to eq("name")
+              end
+            end
+          end
+        end
+
+        context "when not persisting" do
+          it 'should not rollback all changes' do
+            expect(transactor).to be_sleeping
+            expect(worker.status).to eq('sleeping')
+
+            # Notice here we're calling "run" and not "run!" with a bang.
+            expect {transactor.run}.to raise_error(StandardError, 'failed on purpose')
+            expect(transactor).to be_running
+            expect(worker.reload.status).to eq('running')
+          end
+
+          it 'should not create a database transaction' do
+            expect(transactor.class).not_to receive(:transaction)
+            expect {transactor.run}.to raise_error(StandardError, 'failed on purpose')
+          end
+        end
       end
     end
 

--- a/spec/unit/persistence/sequel_persistence_spec.rb
+++ b/spec/unit/persistence/sequel_persistence_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 if defined?(Sequel)
   describe 'sequel' do
-  
+
     Dir[File.dirname(__FILE__) + "/../../models/sequel/*.rb"].sort.each do |f|
       require File.expand_path(f)
     end


### PR DESCRIPTION
Addresses ticket: #474.

I did a little bit of refactoring because there were multiple instances of repeated code. All the persistence classes are much smaller and behavior in the gem can be modified more easily through AASM::Persistence::ORM for Persistence modules that are orm-like.

I tested all the specs for ActiveRecord, Sequel, and Mongoid. I didn't touch other ORMs so didn't feel the need to install a bunch of extra stuff I don't use.

Nevertheless, the CI system here tested the rest and everything passes.

@anilmaurya - please take a look. 