### PR TITLE
Add i18n to events

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -109,6 +109,7 @@ module AASM
 
     # define an event
     def event(name, options={}, &block)
+      options = options.merge(klass: @klass)
       @state_machine.add_event(name, options, &block)
 
       aasm_name = @name.to_sym
@@ -176,10 +177,10 @@ module AASM
       @state_machine.events.values
     end
 
-    # aasm.event(:event_name).human?
-    def human_event_name(event) # event_name?
+    def human_event_name(event)
       AASM::Localizer.new.human_event_name(klass, event)
     end
+    # deprecate :human_event_name, 'Event#human_name'
 
     def states_for_select
       states.map { |state| state.for_select }

--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -6,6 +6,7 @@ module AASM::Core
 
     def initialize(name, state_machine, options = {}, &block)
       @name = name
+      @klass = options[:klass]
       @state_machine = state_machine
       @transitions = []
       @valid_transitions = {}
@@ -106,6 +107,11 @@ module AASM::Core
     def failed_callbacks
       transitions.flat_map(&:failures)
     end
+
+    def human_name
+      @human_name ||= AASM::Localizer.new.human_event_name(@klass, self.name)
+    end
+    alias localized_name human_name
 
   private
 

--- a/lib/aasm/core/state.rb
+++ b/lib/aasm/core/state.rb
@@ -45,31 +45,21 @@ module AASM::Core
       end
     end
 
-    def display_name
-      @display_name ||= begin
-        if Module.const_defined?(:I18n)
-          localized_name
-        else
-          name.to_s.gsub(/_/, ' ').capitalize
-        end
-      end
+    def human_name
+      @human_name ||= AASM::Localizer.new.human_state_name(@klass, self)
     end
-
-    def localized_name
-      AASM::Localizer.new.human_state_name(@klass, self)
-    end
-    alias human_name localized_name
+    alias localized_name human_name
+    alias display_name human_name
+    # deprecate :display_name, :human_name
 
     def for_select
-      [display_name, name.to_s]
+      [human_name, name.to_s]
     end
 
   private
 
     def update(options = {})
-      if options.key?(:display) then
-        @display_name = options.delete(:display)
-      end
+      @human_name = options.delete(:display) if options.key?(:display)
       @options = options
       self
     end

--- a/lib/aasm/localizer.rb
+++ b/lib/aasm/localizer.rb
@@ -1,6 +1,8 @@
 module AASM
   class Localizer
     def human_event_name(klass, event)
+      return no_i18n_fallback(event.name) unless Module.const_defined?(:I18n)
+
       checklist = ancestors_list(klass).inject([]) do |list, ancestor|
         list << :"#{i18n_scope(klass)}.events.#{i18n_klass(ancestor)}.#{event}"
         list
@@ -9,6 +11,8 @@ module AASM
     end
 
     def human_state_name(klass, state)
+      return no_i18n_fallback(state.name) unless Module.const_defined?(:I18n)
+
       checklist = ancestors_list(klass).inject([]) do |list, ancestor|
         list << item_for(klass, state, ancestor)
         list << item_for(klass, state, ancestor, :old_style => true)
@@ -18,6 +22,10 @@ module AASM
     end
 
   private
+
+    def no_i18n_fallback(name)
+      name.to_s.tr('_', ' ').capitalize
+    end
 
     def item_for(klass, state, ancestor, options={})
       separator = options[:old_style] ? '.' : '/'


### PR DESCRIPTION
I created the code to allow the instances of `Event` to have the method `#human_name`. I also moved the code that checked for the presence of the `I18n` module to the `Localizer` class.

I still have to add some tests and find the best way to add a deprecation warning to the old methods.

Fix #478