### PR TITLE
Enable Dynamoid for Rails 5 specs

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -36,9 +36,6 @@ appraise 'rails_5.0' do
   gem 'rails', '5.0.0'
   gem 'mongoid', '~>6.0'
   gem 'sequel'
-
-  # dynamoid is not yet Rails 5 compatible
-  # gem 'dynamoid', '~> 1',                 :platforms => :ruby
-
+  gem 'dynamoid', '~> 1',                 :platforms => :ruby
   gem 'aws-sdk', '~>2',                   :platforms => :ruby
 end

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -7,6 +7,7 @@ gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
 gem "rails", "5.0.0"
 gem "mongoid", "~>6.0"
 gem "sequel"
+gem "dynamoid", "~> 1", :platforms => :ruby
 gem "aws-sdk", "~>2", :platforms => :ruby
 
 gemspec :path => "../"


### PR DESCRIPTION
Dynamoid received Rails 5 support according to https://github.com/Dynamoid/Dynamoid/issues/43#issuecomment-310518341, so we may reenable it in Appraisals.