### PR TITLE
Use AASM::NO_VALUE as `to_state` argument default value

### DIFF
--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -1,4 +1,6 @@
 module AASM
+  # this is used internally as an argument default value to represent no value
+  NO_VALUE = :_aasm_no_value
 
   # provide a state machine for the including class
   # make sure to load class methods as well

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -69,7 +69,7 @@ module AASM::Core
 
       case code
       when Symbol, String
-        result = (record.__send__(:method, code.to_sym).arity != 0 ? record.__send__(code, *args) : record.__send__(code))
+        result = (record.__send__(:method, code.to_sym).arity == 0 ? record.__send__(code) : record.__send__(code, *args))
         failures << code unless result
         result
       when Proc

--- a/spec/unit/complex_example_spec.rb
+++ b/spec/unit/complex_example_spec.rb
@@ -30,14 +30,14 @@ describe 'when being unsuspended' do
   it 'should be able to be unsuspended into active if polite' do
     auth.suspend!
     expect(auth.may_wait?(:waiting, :please)).to be true
-    auth.wait!(nil, :please)
+    auth.wait!(:please)
   end
 
   it 'should not be able to be unsuspended into active if not polite' do
     auth.suspend!
     expect(auth.may_wait?(:waiting)).not_to be true
     expect(auth.may_wait?(:waiting, :rude)).not_to be true
-    expect {auth.wait!(nil, :rude)}.to raise_error(AASM::InvalidTransition)
+    expect {auth.wait!(:rude)}.to raise_error(AASM::InvalidTransition)
     expect {auth.wait!}.to raise_error(AASM::InvalidTransition)
   end
 

--- a/spec/unit/complex_multiple_example_spec.rb
+++ b/spec/unit/complex_multiple_example_spec.rb
@@ -39,18 +39,18 @@ describe 'when being unsuspended' do
   it 'should be able to wait into waiting if polite' do
     auth.left_suspend!
     expect(auth.may_left_wait?(:waiting, :please)).to be true
-    auth.left_wait!(nil, :please)
+    auth.left_wait!(:please)
 
     auth.right_suspend!
     expect(auth.may_right_wait?(:waiting)).to be false
-    auth.right_wait!(nil, :please)
+    auth.right_wait!(:please)
   end
 
   it 'should not be able to be unsuspended into active if not polite' do
     auth.left_suspend!
     expect(auth.may_left_wait?(:waiting)).not_to be true
     expect(auth.may_left_wait?(:waiting, :rude)).not_to be true
-    expect {auth.left_wait!(nil, :rude)}.to raise_error(AASM::InvalidTransition)
+    expect {auth.left_wait!(:rude)}.to raise_error(AASM::InvalidTransition)
     expect {auth.left_wait!}.to raise_error(AASM::InvalidTransition)
   end
 

--- a/spec/unit/event_multiple_spec.rb
+++ b/spec/unit/event_multiple_spec.rb
@@ -37,7 +37,7 @@ describe 'parametrised events' do
   end
 
   it 'should transition to default state when :after transition invoked' do
-    pe.dress!(nil, 'purple', 'dressy')
+    pe.dress!('purple', 'dressy')
     expect(pe.aasm(:left).current_state).to eq(:working)
   end
 

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -106,7 +106,7 @@ describe 'firing an event' do
     obj = double('object', :aasm => double('aasm', :current_state => :open))
     expect(obj).to receive(:guard_fn).with('arg1', 'arg2').and_return(true)
 
-    expect(event.fire(obj, {}, nil, 'arg1', 'arg2')).to eq(:closed)
+    expect(event.fire(obj, {}, 'arg1', 'arg2')).to eq(:closed)
   end
 
   context 'when given a gaurd proc' do
@@ -118,7 +118,7 @@ describe 'firing an event' do
       line_number = __LINE__ - 2
       obj = double('object', :aasm => double('aasm', :current_state => :student))
 
-      event.fire(obj, {}, nil)
+      event.fire(obj, {})
       expect(event.failed_callbacks).to eq ["#{__FILE__}##{line_number}"]
     end
   end
@@ -133,7 +133,7 @@ describe 'firing an event' do
       obj = double('object', :aasm => double('aasm', :current_state => :student))
       allow(obj).to receive(:paid_tuition?).and_return(false)
 
-      event.fire(obj, {}, nil)
+      event.fire(obj, {})
       expect(event.failed_callbacks).to eq [:paid_tuition?]
     end
   end
@@ -315,7 +315,7 @@ describe 'parametrised events' do
   end
 
   it 'should transition to default state when :after transition invoked' do
-    pe.dress!(nil, 'purple', 'dressy')
+    pe.dress!('purple', 'dressy')
     expect(pe.aasm.current_state).to eq(:working)
   end
 


### PR DESCRIPTION
Based on discussion in https://github.com/aasm/aasm/issues/449#issuecomment-318022061

This PR attempts to fix the root cause of a few issues (#449, #416, #441) with this similar error:

```
Wrong number of arguments (given 1, expected 0)
```

This error happens because AASM incorrectly calls guard method with
one extra argument in certain scenarios. For example:

```ruby
def can_do_something?  # guard method with no argument
  ...
end

# But AASM incorrectly triggers `can_do_something?(nil)`
```

This happens because in `AASM::Core::Event#_fire(obj, options={}, to_state=nil, *args)`,
the `to_state` argument default nil value is causing ambiguity, i.e. there is no way for 
AASM to tell whether a caller provides a) one argument with nil value, or b) no argument.

This PR removes this ambiguity by using a symbol as `to_state` default value.