### PR TITLE
Add use transaction flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,24 @@ end
 
 which then leads to `transaction(:requires_new => false)`, the Rails default.
 
+Additionally, if you do not want any of your active record actions to be
+wrapped in a transaction, you can specify the `use_transactions` flag. This can
+be useful if you want want to persist things to the database that happen as a
+result of a transaction or callback, even when some error occurs. The
+`use_transactions` flag is true by default.
+
+```ruby
+class Job < ActiveRecord::Base
+  include AASM
+
+  aasm :use_transactions => false do
+    ...
+  end
+
+  ...
+end
+```
+
 ### Pessimistic Locking
 
 AASM supports [Active Record pessimistic locking via `with_lock`](http://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html#method-i-with_lock) for database persistence layers.

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -26,6 +26,9 @@ module AASM
       # raise if the model is invalid (in ActiveRecord)
       configure :whiny_persistence, false
 
+      # Use transactions (in ActiveRecord)
+      configure :use_transactions, true
+
       # use requires_new for nested transactions (in ActiveRecord)
       configure :requires_new_transaction, true
 

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -15,6 +15,9 @@ module AASM
     # for ActiveRecord: store the new state even if the model is invalid and return true
     attr_accessor :skip_validation_on_save
 
+    # for ActiveRecord: use transactions
+    attr_accessor :use_transactions
+
     # for ActiveRecord: use requires_new for nested transactions?
     attr_accessor :requires_new_transaction
 

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -24,7 +24,7 @@ ActiveRecord::Migration.suppress_messages do
     end
   end
 
-  %w(transactors no_lock_transactors lock_transactors lock_no_wait_transactors multiple_transactors).each do |table_name|
+  %w(transactors no_lock_transactors lock_transactors lock_no_wait_transactors no_transactors multiple_transactors).each do |table_name|
     ActiveRecord::Migration.create_table table_name, :force => true do |t|
       t.string "name"
       t.string "status"

--- a/spec/models/active_record/transactor.rb
+++ b/spec/models/active_record/transactor.rb
@@ -72,6 +72,31 @@ class LockNoWaitTransactor < ActiveRecord::Base
   end
 end
 
+class NoTransactor < ActiveRecord::Base
+
+ belongs_to :worker
+
+  include AASM
+  aasm :column => :status, use_transactions: false do
+    state :sleeping, :initial => true
+    state :running, :before_enter => :start_worker, :after_enter => :fail
+
+    event :run do
+      transitions :to => :running, :from => :sleeping
+    end
+  end
+
+  private
+
+  def start_worker
+    worker.update_attribute(:status, 'running')
+  end
+
+  def fail
+    raise StandardError.new('failed on purpose')
+  end
+end
+
 class MultipleTransactor < ActiveRecord::Base
 
   belongs_to :worker

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -506,6 +506,20 @@ if defined?(ActiveRecord)
       end
     end
 
+    describe 'without transactions' do
+      let(:worker) { Worker.create!(:name => 'worker', :status => 'sleeping') }
+      let(:no_transactor) { NoTransactor.create!(:name => 'transactor', :worker => worker) }
+
+      it 'should not rollback all changes' do
+        expect(no_transactor).to be_sleeping
+        expect(worker.status).to eq('sleeping')
+
+        expect {no_transactor.run!}.to raise_error(StandardError, 'failed on purpose')
+        expect(no_transactor).to be_running
+        expect(worker.reload.status).to eq('running')
+      end
+    end
+
     describe 'transactions' do
       let(:worker) { Worker.create!(:name => 'worker', :status => 'sleeping') }
       let(:transactor) { Transactor.create!(:name => 'transactor', :worker => worker) }


### PR DESCRIPTION
Adds a flag that allows state machines to not use ActiveRecord transactions at all.

This PR is basically #465, so almost all credit goes to @lichtamberg. I simply solved the merge conflict and added this feature to the README.

Closes #431 