### PR TITLE
Fix job.fire to job.aasm.fire in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,8 +691,8 @@ job.run   # not saved
 job.run!  # saved
 
 # or
-job.fire(:run) # not saved
-job.fire!(:run) # saved
+job.aasm.fire(:run) # not saved
+job.aasm.fire!(:run) # saved
 ```
 
 Saving includes running all validations on the `Job` class. If


### PR DESCRIPTION
The Pull request that introduced this #494 wrote the wrong instance on what the method `state_event_instance.fire` could be triggered.

