### PR TITLE
Skip creation of individual scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,22 @@ class Job < ActiveRecord::Base
 end
 ```
 
+If you want to skip creation of individual scopes, disable their creation when
+declaring the scope:
+
+```ruby
+class Job < ActiveRecord::Base
+  include AASM
+
+  aasm do
+    state :sleeping, :initial => true
+    state :locked, :create_scope => false
+    state :running
+    state :cleaning
+  end
+end
+```
+
 
 ### Transaction support
 

--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -55,8 +55,8 @@ module AASM
     # make sure to create a (named) scope for each state
     def state_with_scope(name, *args)
       state_without_scope(name, *args)
-      if @state_machine.config.create_scopes && !@klass.respond_to?(name)
 
+      if should_create_scope?(name, *args)
         if @klass.ancestors.map {|klass| klass.to_s}.include?("ActiveRecord::Base")
           conditions = {"#{@klass.table_name}.#{@klass.aasm(@name).attribute_name}" => name.to_s}
           if ActiveRecord::VERSION::MAJOR >= 3
@@ -84,6 +84,11 @@ module AASM
     end
     alias_method :state_without_scope, :state
     alias_method :state, :state_with_scope
+
+  private
+    def should_create_scope?(name, *args)
+      return @state_machine.config.create_scopes && !@klass.respond_to?(name) && (args.first.blank? || args.first[:create_scope] != false)
+    end
   end # Base
 
 end # AASM

--- a/spec/models/active_record/no_scope.rb
+++ b/spec/models/active_record/no_scope.rb
@@ -19,3 +19,15 @@ class MultipleNoScope < ActiveRecord::Base
     end
   end
 end
+
+class NoLockedScope < ActiveRecord::Base
+  include AASM
+  aasm do
+    state :pending, :initial => true
+    state :locked, :create_scope => false
+    state :running
+    event :run do
+      transitions :from => :pending, :to => :running
+    end
+  end
+end

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -298,6 +298,10 @@ describe "named scopes with the new DSL" do
   it "does not create scopes if requested" do
     expect(MultipleNoScope).not_to respond_to(:pending)
   end
+
+  it "does not create scopes for individual states if requested" do
+    expect(NoLockedScope).not_to respond_to(:locked)
+  end
 end # scopes
 
 describe "direct assignment" do


### PR DESCRIPTION
There is some arel issues if you declare a scope with the name
`locked`, so we need a way to skip the creation the of individual
scopes.

See: https://github.com/rails/rails/issues/7421 for more info