### PR TITLE
Proposal: set state machine name to default

### DIFF
--- a/lib/aasm/persistence/orm.rb
+++ b/lib/aasm/persistence/orm.rb
@@ -115,7 +115,7 @@ module AASM
       end
 
       # Returns true if event was fired successfully and transaction completed.
-      def aasm_fire_event(state_machine_name, name, options, *args, &block)
+      def aasm_fire_event(state_machine_name = :default, name, options, *args, &block)
         if aasm_supports_transactions? && options[:persist]
           event = self.class.aasm(state_machine_name).state_machine.events[name]
           event.fire_callbacks(:before_transaction, self, *args)


### PR DESCRIPTION
We use `aasm_fire_event` in a bunch of places in our codebase and it doesn't make sense to keep passing in `:default` for the `state_machine_name` arg. Proposing that we default the argument to `:default`.

If this is seems like a positive change I'll spend more time and write tests.