### PR TITLE
Adding failed_callbacks example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,6 +1140,11 @@ Job.aasm.states_for_select
 
 # show permitted states with guard parameter
 job.aasm.states({:permitted => true}, guard_parameter).map(&:name)
+
+# show the failed guards (failed_callbacks) for non permitted events
+job.aasm.events(:permitted => false).map { |event| event.failed_callbacks }
+#=> [:cleaning_needed?]
+
 ```
 
 


### PR DESCRIPTION
Adding `failed_callbacks` example to the Inspection Section
Resolves issue #555 in terms of AASM knowledge :-)