### PR TITLE
Set current event on fire (Fixes 551)

### DIFF
--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -104,10 +104,14 @@ module AASM
     end
 
     def fire(event_name, *args, &block)
+      aasm_name = @name.to_sym
+      @instance.aasm(aasm_name).current_event = :"#{event_name}"
       @instance.send(:aasm_fire_event, @name, event_name, {persist: false}, *args, &block)
     end
 
     def fire!(event_name, *args, &block)
+      aasm_name = @name.to_sym
+      @instance.aasm(aasm_name).current_event = :"#{event_name}!"
       @instance.send(:aasm_fire_event, @name, event_name, {persist: true}, *args, &block)
     end
 

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -285,13 +285,23 @@ describe 'current event' do
     expect(pe.aasm.current_event).to be_nil
   end
 
-  it 'if a event has been triggered' do
+  it 'if a event has been triggered with event_name' do
     pe.wakeup
     expect(pe.aasm.current_event).to eql :wakeup
   end
 
-  it 'if no event has been triggered' do
+  it 'if a event has been triggered using fire(:event_name)' do
+    pe.aasm.fire(:wakeup)
+    expect(pe.aasm.current_event).to eql :wakeup
+  end
+
+  it 'if event has been triggered with a event_name!' do
     pe.wakeup!
+    expect(pe.aasm.current_event).to eql :wakeup!
+  end
+
+  it 'if event has been triggered with a fire!(:event_name)' do
+    pe.aasm.fire!(:wakeup)
     expect(pe.aasm.current_event).to eql :wakeup!
   end
 end


### PR DESCRIPTION
Updates the `fire` and `fire!` methods to set the current event. Fixes #551 

