### PR TITLE
WIP FactoryBot integration

### DIFF
--- a/lib/aasm/factory_bot.rb
+++ b/lib/aasm/factory_bot.rb
@@ -1,0 +1,16 @@
+Rails.root.glob("app/models/*.rb").each {|path| require path }
+
+FactoryBot.modify do
+  AASM::StateMachineStore.stores.each do |model_name, store|
+    factory_name = model_name.underscore.to_sym
+    next unless FactoryBot.factories.registered?(factory_name)
+
+    factory factory_name do
+      store["default"].states.each do |state|
+        trait state.name do
+          aasm_state { state.name }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a bit of an exploratory PR to provide some automatic integration with FactoryBot.

This is a pattern I've wound up using fairly frequently, which adds a trait for each state so we can easily create an object in a starting state using that state as a trait, for example:

person.rb
```
include AASM
aasm do
  state :unverified, initial: true
  state :verified
end
```

person_factory.rb
```
FactoryBot.create(:person, :verified)
```

It would be invoked by calling `require "aasm/factory_bot"` in `rails_helper.rb` (or similar) *after* the factories have been `require`d.

Issues:
- It's a bit Rails-y in two ways, 1) it needs the first line to ensure the state machines have all been registered, since in test mode Rails will lazy-load models, 2) it assumes that `aasm_state` is an attribute and the correct one to set.
- I haven't looked into the reason that a class can have more than one machine registered, so for now it just checks the `default` one.

Thoughts?