### PR TITLE
Update InvalidTransition to include state_machine_name

### DIFF
--- a/lib/aasm/errors.rb
+++ b/lib/aasm/errors.rb
@@ -3,10 +3,11 @@ module AASM
   class UnknownStateMachineError < RuntimeError; end
 
   class InvalidTransition < RuntimeError
-    attr_reader :object, :event_name, :originating_state, :failures
+    attr_reader :object, :event_name, :originating_state, :failures, :state_machine
 
     def initialize(object, event_name, state_machine_name, failures = [])
       @object, @event_name, @originating_state, @failures = object, event_name, object.aasm(state_machine_name).current_state, failures
+      @state_machine = state_machine_name
       super("Event '#{event_name}' cannot transition from '#{originating_state}'.#{reasoning}")
     end
 


### PR DESCRIPTION
For easier debugging and error handling for models with multiple state_machines.
This non-breaking change add the state_machine name to the attributes of the InvalidTransition error