### PR TITLE
Update docs to more accurately reflect behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Also, you can pass parameters to events:
 
 In this case the `set_process` would be called with `:defragmentation` argument.
 
-Note that when passing arguments to a state transition, the first argument must be the desired end state. In the above example, we wish to transition to `:running` state and run the callback with `:defragmentation` argument. You can also pass in `nil` as the desired end state, and AASM will try to transition to the first end state defined for that event.
+Note that when passing arguments to a state transition, the first argument should be the desired end state. In the above example, we wish to transition to `:running` state and run the callback with `:defragmentation` argument. You can also omit or pass in `nil` as the desired end state, and AASM will try to transition to the first end state defined for that event.
 
 In case of an error during the event processing the error is rescued and passed to `:error`
 callback, which can handle it or re-raise it for further propagation.


### PR DESCRIPTION
Usage of the word "must" in the current documentation is not accurate, if the first argument to a transition is not a valid end state, `to_state` will be set to `nil` and the arg will be unshifted to the args that get passed to callbacks: 

https://github.com/aasm/aasm/blob/cd25a1eeaeaec49238ec19b6cdd2b28d23c56f71/lib/aasm/core/event.rb#L135-L139