### PR TITLE
Clarify `on_event` can accept *multiple* events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,7 +1213,7 @@ expect(job).to allow_event :run
 expect(job).to_not allow_event :clean
 expect(job).to allow_transition_to(:running)
 expect(job).to_not allow_transition_to(:cleaning)
-# on_event also accept arguments
+# on_event also accept multiple arguments
 expect(job).to transition_from(:sleeping).to(:running).on_event(:run, :defragmentation)
 
 # classes with multiple state machine


### PR DESCRIPTION
It was clear it could have accept arguments as the previous examples already did cover the case. This chagne clarifies what the examples is covering.