### PR TITLE
fix warning: shadowing outer local variable - block

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -124,14 +124,14 @@ module AASM
         aasm(aasm_name).may_fire_event?(event, *args)
       end
 
-      safely_define_method klass, "#{name}!", ->(*args, &block) do
+      safely_define_method klass, "#{name}!", ->(*args, &inner_block) do
         aasm(aasm_name).current_event = :"#{name}!"
-        aasm_fire_event(aasm_name, event, {:persist => true}, *args, &block)
+        aasm_fire_event(aasm_name, event, {:persist => true}, *args, &inner_block)
       end
 
-      safely_define_method klass, name, ->(*args, &block) do
+      safely_define_method klass, name, ->(*args, &inner_block) do
         aasm(aasm_name).current_event = event
-        aasm_fire_event(aasm_name, event, {:persist => false}, *args, &block)
+        aasm_fire_event(aasm_name, event, {:persist => false}, *args, &inner_block)
       end
 
       # Create aliases for the event methods. Keep the old names to maintain backwards compatibility.


### PR DESCRIPTION
Using this gem in my project, I encounter this error when running with `-W2` set.

```
/application/lib/aasm/base.rb:127: warning: shadowing outer local variable - block
/application/lib/aasm/base.rb:132: warning: shadowing outer local variable - block
```