### PR TITLE
Minitest - ensure assertion does not raise if transition is invalid (return false instead)

### DIFF
--- a/lib/aasm/minitest/transition_from.rb
+++ b/lib/aasm/minitest/transition_from.rb
@@ -17,5 +17,7 @@ module Minitest::Assertions
     state_machine_name = options[:on]
     object.aasm(state_machine_name).current_state = from_state.to_sym
     object.send(options[:on_event], *args) && options[:to].to_sym == object.aasm(state_machine_name).current_state
+  rescue AASM::InvalidTransition
+    false
   end
 end


### PR DESCRIPTION
Given a state machine:

```ruby
class Cleaner
  include AASM

  aasm do
    state :idle, initial: true
    state :cleaning

    event :clean do
      transitions from: :idle, to: :cleaning, guard: :cleaning_needed?
    end
  end

  def cleaning_needed?
    false
  end
end
```

A test that does:

```ruby
cleaner = Cleaner.new
refute_transitions_from cleaner, :idle, to: :cleaning, on_event: :clean
```
will raise a `AASM::InvalidTransition` exception. 

I believe a nicer behavior would be for the test to pass, instead.