### PR TITLE
Raise proper error when fire an unknown event

### DIFF
--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -96,6 +96,7 @@ private
 
   def aasm_fire_event(state_machine_name, event_name, options, *args, &block)
     event = self.class.aasm(state_machine_name).state_machine.events[event_name]
+    raise AASM::UndefinedState, "State :#{event_name} doesn't exist" if event.nil?
     begin
       old_state = aasm(state_machine_name).state_object_for_name(aasm(state_machine_name).current_state)
 
@@ -117,6 +118,7 @@ private
       raise(e)
       false
     ensure
+      return if event.nil?
       event.fire_callbacks(:ensure, self, *process_args(event, aasm(state_machine_name).current_state, *args))
       event.fire_global_callbacks(:ensure_on_all_events, self, *process_args(event, aasm(state_machine_name).current_state, *args))
     end

--- a/spec/unit/complex_example_spec.rb
+++ b/spec/unit/complex_example_spec.rb
@@ -91,4 +91,8 @@ describe 'when being unsuspended' do
     expect(auth.aasm.may_fire_event?(:unknown)).to be false
   end
 
+  it "should raise AASM::UndefinedState when fire unknown events" do
+    expect { auth.aasm.fire(:unknown) }.to raise_error(AASM::UndefinedState, "State :unknown doesn't exist")
+    expect(auth.aasm.current_state).to eq(:pending)
+  end
 end


### PR DESCRIPTION
Should fix #618 

if an unknown event was fired:
- raise `AASM::UndefinedState` 
- don't run callbacks