### PR TITLE
Fix docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-ARG RVM_RUBY_VERSIONS="2.4.0 2.5.0"
-ARG RVM_RUBY_DEFAULT="2.4.0"
-FROM msati/docker-rvm
-
-# After Ruby versions are installed we continue as non-root rvm user
-USER ${RVM_USER}
+FROM ruby:2.3.4-slim
 
 LABEL maintainer="AASM"
 


### PR DESCRIPTION
Fix for #640

I was trying to make the `msati/docker-rvm` image work but after fixing the issue with permissions and locales, I still wasn't able to run tests in the created container. 

Revert the usage of a previously used image `ruby:2.3.4-slim`. 