### PR TITLE
Introduces instance level skip validation option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,14 @@ class Job < ActiveRecord::Base
 end
 ```
 
+Also You can skip the validation at instance level with `some_event_name_without_validation!` method.
+With this you have the flexibility of having validation for all your transitions by default and then skip it wherever required.
+Please note that only state column will be updated as mentioned in the above example.
+
+```ruby
+job.run_without_validation!
+```
+
 If you want to make sure that the _AASM_ column for storing the state is not directly assigned,
 configure _AASM_ to not allow direct assignment, like this:
 

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -51,4 +51,9 @@ ActiveRecord::Migration.suppress_messages do
     t.string "search"
     t.string "sync"
   end
+
+  ActiveRecord::Migration.create_table "instance_level_skip_validation_examples", :force => true do |t|
+    t.string "state"
+    t.string "some_string"
+  end
 end

--- a/spec/models/active_record/instance_level_skip_validation_example.rb
+++ b/spec/models/active_record/instance_level_skip_validation_example.rb
@@ -1,0 +1,19 @@
+class InstanceLevelSkipValidationExample < ActiveRecord::Base
+  include AASM
+
+  aasm :state do
+    state :new, :initial => true
+    state :draft
+    state :complete
+
+    event :set_draft do
+      transitions from: :new, to: :draft
+    end
+
+    event :complete do
+      transitions from: %i[draft new], to: :complete
+    end
+  end
+
+  validates :some_string, presence: true
+end

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -748,4 +748,26 @@ if defined?(ActiveRecord)
       expect { job.run }.to raise_error(AASM::InvalidTransition)
     end
   end
+
+  describe 'testing the instance_level skip validation with _without_validation method' do
+    let(:example) do
+      obj = InstanceLevelSkipValidationExample.new(state: 'new')
+      obj.save(validate: false)
+      obj
+    end
+
+    it 'should be able to change the state with invalid record' do
+      expect(example.valid?).to be_falsey
+      expect(example.complete!).to be_falsey
+      expect(example.complete_without_validation!).to be_truthy
+      expect(example.state).to eq('complete')
+    end
+
+    it 'shouldn\'t affect the behaviour of existing method after calling _without_validation! method' do
+      expect(example.set_draft!).to be_falsey
+      expect(example.set_draft_without_validation!).to be_truthy
+      expect(example.state).to eq('draft')
+      expect(example.complete!).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
We had a specific requirement to skip validations for transitions at the instance level at a few places but at the same time, we wanted the transitions for the model to validated at other places.

The change in this PR just adds a method like

`some_event_name_without_validation!` which actually skips the validation and set the object state according to the transitions defined.