### PR TITLE
handle AASM::InvalidTransition in RSpec `transition_from` matcher

### DIFF
--- a/lib/aasm/rspec/transition_from.rb
+++ b/lib/aasm/rspec/transition_from.rb
@@ -2,7 +2,11 @@ RSpec::Matchers.define :transition_from do |from_state|
   match do |obj|
     @state_machine_name ||= :default
     obj.aasm(@state_machine_name).current_state = from_state.to_sym
-    obj.send(@event, *@args) && obj.aasm(@state_machine_name).current_state == @to_state.to_sym
+    begin
+      obj.send(@event, *@args) && obj.aasm(@state_machine_name).current_state == @to_state.to_sym
+    rescue AASM::InvalidTransition
+      false
+    end
   end
 
   chain :on do |state_machine_name|

--- a/spec/unit/rspec_matcher_spec.rb
+++ b/spec/unit/rspec_matcher_spec.rb
@@ -8,14 +8,17 @@ describe 'state machine' do
     it "works for simple state machines" do
       expect(simple).to transition_from(:initialised).to(:filled_out).on_event(:fill_out)
       expect(simple).to_not transition_from(:initialised).to(:authorised).on_event(:fill_out)
+      expect(simple).to_not transition_from(:authorised).to(:filled_out).on_event(:fill_out)
     end
 
     it "works for multiple state machines" do
       expect(multiple).to transition_from(:standing).to(:walking).on_event(:walk).on(:move)
       expect(multiple).to_not transition_from(:standing).to(:running).on_event(:walk).on(:move)
+      expect(multiple).to_not transition_from(:running).to(:walking).on_event(:walk).on(:move)
 
       expect(multiple).to transition_from(:sleeping).to(:processing).on_event(:start).on(:work)
       expect(multiple).to_not transition_from(:sleeping).to(:sleeping).on_event(:start).on(:work)
+      expect(multiple).to_not transition_from(:processing).to(:sleeping).on_event(:start).on(:work)
     end
   end
 


### PR DESCRIPTION
When using the `transition_from` RSpec matcher, it returns false when the "from" state is valid but raises an exception when the "from" state is not valid. This commit aligns the two paths so the matcher will return false in both scenarios.