### PR TITLE
Adds `after_commit` for states and implements `after_all_commits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,13 +936,15 @@ Since version *3.0.13* AASM supports ActiveRecord transactions. So whenever a tr
 callback or the state update fails, all changes to any database record are rolled back.
 Mongodb does not support transactions.
 
-There are currently 3 transactional callbacks that can be handled on the event, and 2 transactional callbacks for all events.
+There are currently 3 transactional callbacks that can be handled on the event, and 3 transactional callbacks for all events, and 1 transaction callback for states.
 
 ```ruby
   event           before_all_transactions
   event           before_transaction
   event           aasm_fire_event (within transaction)
+  new_state       after_commit (if event successful)
   event           after_commit (if event successful)
+  event           after_all_commits (if event successful)
   event           after_transaction
   event           after_all_transactions
 ```

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -150,6 +150,10 @@ module AASM
       @state_machine.add_global_callbacks(:after_all_transitions, *callbacks, &block)
     end
 
+    def after_all_commits(*callbacks, &block)
+      @state_machine.add_global_callbacks(:after_all_commits, *callbacks, &block)
+    end
+
     def after_all_transactions(*callbacks, &block)
       @state_machine.add_global_callbacks(:after_all_transactions, *callbacks, &block)
     end

--- a/lib/aasm/persistence/orm.rb
+++ b/lib/aasm/persistence/orm.rb
@@ -131,6 +131,9 @@ module AASM
             end
 
             if success
+              new_state = self.class.aasm(state_machine_name).state_object_for_name(aasm(state_machine_name).current_state)
+              new_state.fire_callbacks(:after_commit, self, *args)
+
               event.fire_callbacks(:after_commit, self, *args)
               event.fire_global_callbacks(:after_all_commits, self, *args)
             end

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -508,6 +508,10 @@ if defined?(ActiveRecord)
           validator.sleep!("sleeper")
           expect(validator).to be_sleeping
           expect(validator.name).to eq("sleeper")
+
+          validator.eat!
+          expect(validator).to be_eating
+          expect(validator.name).to eq("eater")
         end
 
         it "should not fire :after_commit if transaction failed" do

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -590,6 +590,10 @@ if defined?(ActiveRecord)
           validator.sleep!("sleeper")
           expect(validator).to be_sleeping
           expect(validator.name).to eq("sleeper")
+
+          validator.eat!
+          expect(validator).to be_eating
+          expect(validator.name).to eq("eater")
         end
 
         it "should not fire :after_commit if transaction failed" do
@@ -645,6 +649,27 @@ if defined?(ActiveRecord)
               expect(validator.name).to eq("name")
             end
           end
+        end
+      end
+
+      describe 'after all commits callback' do
+        it "should fire :after_all_commits if transaction was successful" do
+          validator = Validator.create(:name => 'name')
+          expect(validator).to be_sleeping
+
+          expect { validator.run! }.to change { validator.after_all_commits_performed }.from(nil).to(true)
+          expect(validator).to be_running
+        end
+
+        it "should not fire :after_all_commits if transaction failed" do
+          validator = Validator.create(:name => 'name')
+          expect do
+            begin
+              validator.fail!
+            rescue => ignored
+            end
+          end.to_not change { validator.after_all_commits_performed }
+          expect(validator).to_not be_running
         end
       end
 


### PR DESCRIPTION
I added `after_commit` to make it easier to add callbacks that require a commit to happen after various state changes happen (i.e. enqueueing a job and preventing the race condition there).

Furthermore, I added `after_all_commits` since it appears the required code is already there (see lib/aasm/persistence/orm.rb) 
