### PR TITLE
Travis: use jruby-9.1.17.0 for a 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 cache: bundler
 
@@ -16,7 +15,7 @@ rvm:
   - 2.5.0
   - 2.6.5
   - 2.7.0
-  - jruby-9.1.12.0
+  - jruby-9.1.17.0
 
 services:
   - mongodb
@@ -82,17 +81,17 @@ matrix:
       gemfile: gemfiles/rails_4.2_mongoid_5.gemfile
 #    - rvm: 2.5.0
 #      gemfile: gemfiles/rails_4.2_nobrainer.gemfile
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.17.0
       gemfile: gemfiles/norails.gemfile
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_5.1.gemfile
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_5.2.gemfile
-#    - rvm: jruby-9.1.12.0
+#    - rvm: jruby-9.1.17.0
 #      gemfile: gemfiles/rails_4.2_nobrainer.gemfile
-#    - rvm: jruby-9.1.12.0
+#    - rvm: jruby-9.1.17.0
 #      gemfile: gemfiles/rails_5.0_nobrainer.gemfile
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 cache: bundler
 
-jdk:
-  - openjdk8
-
 before_install:
   - rvm list
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
@@ -15,7 +12,6 @@ rvm:
   - 2.5.0
   - 2.6.5
   - 2.7.0
-  - jruby-9.1.17.0
 
 services:
   - mongodb
@@ -46,6 +42,15 @@ script:
   - bundle exec rake test
 
 matrix:
+  include:
+    - &jruby_9_1_job
+      rvm: jruby-9.1.17.0
+      jdk: openjdk8
+      gemfile: gemfiles/rails_3.2.gemfile
+    - <<: *jruby_9_1_job
+      gemfile: gemfiles/rails_4.2.gemfile
+    - <<: *jruby_9_1_job
+      gemfile: gemfiles/rails_4.2_mongoid_5.gemfile
   exclude:
     - rvm: 2.3.0
       gemfile: gemfiles/norails.gemfile
@@ -81,18 +86,6 @@ matrix:
       gemfile: gemfiles/rails_4.2_mongoid_5.gemfile
 #    - rvm: 2.5.0
 #      gemfile: gemfiles/rails_4.2_nobrainer.gemfile
-    - rvm: jruby-9.1.17.0
-      gemfile: gemfiles/norails.gemfile
-    - rvm: jruby-9.1.17.0
-      gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: jruby-9.1.17.0
-      gemfile: gemfiles/rails_5.1.gemfile
-    - rvm: jruby-9.1.17.0
-      gemfile: gemfiles/rails_5.2.gemfile
-#    - rvm: jruby-9.1.17.0
-#      gemfile: gemfiles/rails_4.2_nobrainer.gemfile
-#    - rvm: jruby-9.1.17.0
-#      gemfile: gemfiles/rails_5.0_nobrainer.gemfile
 
 notifications:
   slack:


### PR DESCRIPTION
This PR configures **builds for JRuby** in a "positive" (include, not exclude) way.

- Drop the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
- Update matrix to latest released JRuby 9.1, which is [9.1.17.0 April 23, 2018](https://www.jruby.org/2018/04/23/jruby-9-1-17-0.html)
- Use "include" instead of "exclude" to pick gemfiles for JRuby
- Only pick a specific JDK for JRuby
- Still 🍏 

Thanks for maintaining this library!

