### PR TITLE
Add simple option for auto-generated timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [Extending AASM](#extending-aasm)
   - [ActiveRecord](#activerecord)
   - [Bang events](#bang-events)
+  - [Timestamps](#timestamps)
   - [ActiveRecord enums](#activerecord-enums)
   - [Sequel](#sequel)
   - [Dynamoid](#dynamoid)
@@ -776,6 +777,37 @@ job.aasm_state # => 'sleeping'
 job.aasm_state = :running # => raises AASM::NoDirectAssignmentError
 job.aasm_state # => 'sleeping'
 ```
+
+### Timestamps
+
+You can tell _AASM_ to try to write a timestamp whenever a new state is entered.
+If `timestamps: true` is set, _AASM_ will look for a field named like the new state plus `_at` and try to fill it:
+
+```ruby
+class Job < ActiveRecord::Base
+  include AASM
+
+  aasm timestamps: true do
+    state :sleeping, initial: true
+    state :running
+
+    event :run do
+      transitions from: :sleeping, to: :running
+    end
+  end
+end
+```
+
+resulting in this:
+
+```ruby
+job = Job.create
+job.running_at # => nil
+job.run!
+job.running_at # => 2020-02-20 20:00:00
+```
+
+Missing timestamp fields are silently ignored, so it is not necessary to have setters (such as ActiveRecord columns) for *all* states when using this option.
 
 #### ActiveRecord enums
 

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -24,6 +24,9 @@ module AASM
     # for ActiveRecord: use pessimistic locking
     attr_accessor :requires_lock
 
+    # automatically set `"#{state_name}_at" = ::Time.now` on state changes
+    attr_accessor :timestamps
+
     # forbid direct assignment in aasm_state column (in ActiveRecord)
     attr_accessor :no_direct_assignment
 

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -56,4 +56,9 @@ ActiveRecord::Migration.suppress_messages do
     t.string "state"
     t.string "some_string"
   end
+
+  ActiveRecord::Migration.create_table "timestamp_examples", :force => true do |t|
+    t.string "aasm_state"
+    t.datetime "opened_at"
+  end
 end

--- a/spec/models/active_record/timestamp_example.rb
+++ b/spec/models/active_record/timestamp_example.rb
@@ -1,0 +1,16 @@
+class TimestampExample < ActiveRecord::Base
+  include AASM
+
+  aasm column: :aasm_state, timestamps: true do
+    state :opened
+    state :closed
+
+    event :open do
+      transitions to: :opened
+    end
+
+    event :close do
+      transitions to: :closed
+    end
+  end
+end

--- a/spec/models/mongoid/timestamp_example_mongoid.rb
+++ b/spec/models/mongoid/timestamp_example_mongoid.rb
@@ -1,0 +1,20 @@
+class TimestampExampleMongoid
+  include Mongoid::Document
+  include AASM
+
+  field :status, type: String
+  field :opened_at, type: Time
+
+  aasm column: :status, timestamps: true do
+    state :opened
+    state :closed
+
+    event :open do
+      transitions to: :opened
+    end
+
+    event :close do
+      transitions to: :closed
+    end
+  end
+end

--- a/spec/models/timestamps_example.rb
+++ b/spec/models/timestamps_example.rb
@@ -1,0 +1,19 @@
+class TimestampsExample
+  include AASM
+
+  attr_accessor :opened_at
+  attr_reader :closed_at
+
+  aasm timestamps: true do
+    state :opened
+    state :closed
+
+    event :open do
+      transitions to: :opened
+    end
+
+    event :close do
+      transitions to: :closed
+    end
+  end
+end

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -770,4 +770,16 @@ if defined?(ActiveRecord)
       expect(example.complete!).to be_falsey
     end
   end
+
+  describe 'testing the timestamps option' do
+    let(:example) { TimestampExample.create! }
+
+    it 'should update existing timestamp columns' do
+      expect { example.open! }.to change { example.reload.opened_at }.from(nil).to(instance_of(::Time))
+    end
+
+    it 'should not fail if there is no corresponding timestamp column' do
+      expect { example.close! }.to change { example.reload.aasm_state }
+    end
+  end
 end

--- a/spec/unit/persistence/mongoid_persistence_spec.rb
+++ b/spec/unit/persistence/mongoid_persistence_spec.rb
@@ -161,5 +161,17 @@ if defined?(Mongoid::Document)
       end
     end
 
+    describe 'testing the timestamps option' do
+      let(:example) { TimestampExampleMongoid.create }
+
+      it 'should update existing timestamp fields' do
+        expect { example.open! }.to change { example.reload.opened_at }.from(nil).to(instance_of(::Time))
+      end
+
+      it 'should not fail if there is no corresponding timestamp field' do
+        expect { example.close! }.to change { example.reload.status }
+      end
+    end
+
   end
 end

--- a/spec/unit/timestamps_spec.rb
+++ b/spec/unit/timestamps_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'timestamps option' do
+  it 'calls a timestamp setter based on the state name when entering a new state' do
+    object = TimestampsExample.new
+    expect { object.open }.to change { object.opened_at }.from(nil).to(instance_of(::Time))
+  end
+
+  it 'overwrites any previous timestamp if a state is entered repeatedly' do
+    object = TimestampsExample.new
+    object.opened_at = ::Time.new(2000, 1, 1)
+    expect { object.open }.to change { object.opened_at }
+  end
+
+  it 'does nothing if there is no setter matching the new state' do
+    object = TimestampsExample.new
+    expect { object.close }.not_to change { object.closed_at }
+  end
+
+  it 'can be turned off and on' do
+    object = TimestampsExample.new
+    object.class.aasm.state_machine.config.timestamps = false
+    expect { object.open }.not_to change { object.opened_at }
+    object.class.aasm.state_machine.config.timestamps = true
+    expect { object.open }.to change { object.opened_at }
+  end
+end


### PR DESCRIPTION
This aims to solve #418 in a slightly simpler way than #427 - by setting up a callback that, upon entering state `foo`, checks if there is a setter `foo_at=` and if so, uses it.

I've only added tests for POROs and ActiveRecord. I suspect this will work for most ORMs, but haven't looked into that.

If this is accepted it might make sense to mention the new option in the README. I just didn't know where to put it in there.