### PR TITLE
Restrict codecov dependency to < 0.1.19

### DIFF
--- a/aasm.gemspec
+++ b/aasm.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'generator_spec'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "codecov", ">= 0.1.10"
+  s.add_development_dependency "codecov", ">= 0.1.17", '< 0.1.20'
 
   # debugging
   # s.add_development_dependency 'debugger'


### PR DESCRIPTION
As you can see, CI build for [the first commit in this PR](https://github.com/aasm/aasm/pull/690/commits/34fe926e708e065fad14637cd6ac2d57702e4060) (which is empty) [fails](https://travis-ci.org/github/aasm/aasm/builds/711757792) because new version of `codecov` gem was [released](https://rubygems.org/gems/codecov/versions).

I restrict the version of the `codecov` gem to last working version (`0.1.19`).

[This commit in codecov](https://github.com/codecov/codecov-ruby/pull/70/files#diff-d29f661aa1c5a3ea078acedd14427b58R320) breaks jruby compatibility. I will make a PR into `codecov` as well. But lets make this temporary workaround for the time being.

I need this change in my another PR - https://github.com/aasm/aasm/pull/689.