### PR TITLE
Remove needless require ostruct statement

### DIFF
--- a/lib/aasm.rb
+++ b/lib/aasm.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 require 'aasm/version'
 require 'aasm/errors'
 require 'aasm/configuration'


### PR DESCRIPTION
ostruct is no longer required since v4.0.0
ref. 55f1eed4fa2e01a95ca35be0231ad5181939deb6