### PR TITLE
Relocate DslHelper from root namespace to under AASM namespace

### DIFF
--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -2,7 +2,7 @@
 
 module AASM::Core
   class Event
-    include DslHelper
+    include AASM::DslHelper
 
     attr_reader :name, :state_machine, :options
 

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -2,7 +2,7 @@
 
 module AASM::Core
   class Transition
-    include DslHelper
+    include AASM::DslHelper
 
     attr_reader :from, :to, :event, :opts, :failures
     alias_method :options, :opts

--- a/lib/aasm/dsl_helper.rb
+++ b/lib/aasm/dsl_helper.rb
@@ -1,30 +1,32 @@
-module DslHelper
+module AASM
+  module DslHelper
 
-  class Proxy
-    attr_accessor :options
+    class Proxy
+      attr_accessor :options
 
-    def initialize(options, valid_keys, source)
-      @valid_keys = valid_keys
-      @source = source
+      def initialize(options, valid_keys, source)
+        @valid_keys = valid_keys
+        @source = source
 
-      @options = options
-    end
+        @options = options
+      end
 
-    def method_missing(name, *args, &block)
-      if @valid_keys.include?(name)
-        options[name] = Array(options[name])
-        options[name] << block if block
-        options[name] += Array(args)
-      else
-        @source.send name, *args, &block
+      def method_missing(name, *args, &block)
+        if @valid_keys.include?(name)
+          options[name] = Array(options[name])
+          options[name] << block if block
+          options[name] += Array(args)
+        else
+          @source.send name, *args, &block
+        end
       end
     end
-  end
 
-  def add_options_from_dsl(options, valid_keys, &block)
-    proxy = Proxy.new(options, valid_keys, self)
-    proxy.instance_eval(&block)
-    proxy.options
-  end
+    def add_options_from_dsl(options, valid_keys, &block)
+      proxy = Proxy.new(options, valid_keys, self)
+      proxy.instance_eval(&block)
+      proxy.options
+    end
 
+  end
 end


### PR DESCRIPTION
I relocated `DslHelper` module from the root namespace to under the AASM namespace.
Because it is a module for AASM and should not be located in the root namespace.