### PR TITLE
Relax codecov required version and bump minimum version

### DIFF
--- a/aasm.gemspec
+++ b/aasm.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'generator_spec'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "codecov", ">= 0.1.17", '<= 0.2.11'
+  s.add_development_dependency "codecov", ">= 0.1.21"
 
   # debugging
   # s.add_development_dependency 'debugger'


### PR DESCRIPTION
codecov < v0.1.21 are already yanked in rubygems.org.
https://rubygems.org/gems/codecov/versions