### PR TITLE
Event localizer improvement

### DIFF
--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -110,6 +110,10 @@ module AASM::Core
       transitions.flat_map(&:failures)
     end
 
+    def to_s
+      name.to_s
+    end
+
   private
 
     def attach_event_guards(definitions)

--- a/spec/unit/localizer_spec.rb
+++ b/spec/unit/localizer_spec.rb
@@ -29,12 +29,28 @@ if defined?(ActiveRecord)
     end
 
     context 'aasm.human_event_name' do
-      it 'should return translated event name' do
-        expect(LocalizerTestModel.aasm.human_event_name(:close)).to eq("Let's close it!")
+      context 'with event name' do
+        it 'should return translated event name' do
+          expect(LocalizerTestModel.aasm.human_event_name(:close)).to eq("Let's close it!")
+        end
+
+        it 'should return humanized event name' do
+          expect(LocalizerTestModel.aasm.human_event_name(:open)).to eq("Open")
+        end
       end
 
-      it 'should return humanized event name' do
-        expect(LocalizerTestModel.aasm.human_event_name(:open)).to eq("Open")
+      context 'with event object' do
+        it 'should return translated event name' do
+          event = LocalizerTestModel.aasm.events.detect { |e| e.name == :close }
+
+          expect(LocalizerTestModel.aasm.human_event_name(event)).to eq("Let's close it!")
+        end
+
+        it 'should return humanized event name' do
+          event = LocalizerTestModel.aasm.events.detect { |e| e.name == :open }
+
+          expect(LocalizerTestModel.aasm.human_event_name(event)).to eq("Open")
+        end
       end
     end
   end
@@ -65,12 +81,28 @@ if defined?(ActiveRecord)
     end
 
     context 'aasm.human_event_name' do
-      it 'should return translated event name' do
-        expect(LocalizerTestModel.aasm.human_event_name(:close)).to eq("Let's close it!")
+      context 'with event name' do
+        it 'should return translated event name' do
+          expect(LocalizerTestModel.aasm.human_event_name(:close)).to eq("Let's close it!")
+        end
+
+        it 'should return humanized event name' do
+          expect(LocalizerTestModel.aasm.human_event_name(:open)).to eq("Open")
+        end
       end
 
-      it 'should return humanized event name' do
-        expect(LocalizerTestModel.aasm.human_event_name(:open)).to eq("Open")
+      context 'with event object' do
+        it 'should return translated event name' do
+          event = LocalizerTestModel.aasm.events.detect { |e| e.name == :close }
+
+          expect(LocalizerTestModel.aasm.human_event_name(event)).to eq("Let's close it!")
+        end
+
+        it 'should return humanized event name' do
+          event = LocalizerTestModel.aasm.events.detect { |e| e.name == :open }
+
+          expect(LocalizerTestModel.aasm.human_event_name(event)).to eq("Open")
+        end
       end
     end
   end


### PR DESCRIPTION
Related to https://github.com/aasm/aasm/issues/721

## Summary

This PR adds `#to_s` method to `AASM::Core::Event` so we can directly use `Model.aasm.human_event_name(event_object)`. 
Following is the relevant code with addition to `#to_s` enables us to pass `event_object`.
https://github.com/aasm/aasm/blob/ea041603fb72b801d4944aa8b5876ac3ca5a36d2/lib/aasm/localizer.rb#L5