### PR TITLE
Update version in recommendation to add after_commit_everywhere

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -8,7 +8,7 @@ appraise 'rails_4.2' do
   gem 'aws-sdk', '~> 2', platforms: :ruby
   gem 'redis-objects'
   gem 'activerecord-jdbcsqlite3-adapter', '1.3.24', platforms: :jruby
-  gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+  gem "after_commit_everywhere", "~> 1.0"
 end
 
 appraise 'rails_4.2_nobrainer' do
@@ -21,7 +21,7 @@ appraise 'rails_4.2_mongoid_5' do
   gem 'rails', '4.2.5'
   gem 'mongoid', '~> 5.0'
   gem 'activerecord-jdbcsqlite3-adapter', '1.3.24', platforms: :jruby
-  gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+  gem "after_commit_everywhere", "~> 1.0"
 end
 
 appraise 'rails_5.0' do
@@ -31,7 +31,7 @@ appraise 'rails_5.0' do
   gem 'dynamoid', '~> 1.3', platforms: :ruby
   gem 'aws-sdk', '~> 2', platforms: :ruby
   gem 'redis-objects'
-  gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+  gem "after_commit_everywhere", "~> 1.0"
 end
 
 appraise 'rails_5.0_nobrainer' do
@@ -46,7 +46,7 @@ appraise 'rails_5.1' do
   gem 'dynamoid', '~> 1.3', platforms: :ruby
   gem 'aws-sdk', '~>2', platforms: :ruby
   gem 'redis-objects'
-  gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+  gem "after_commit_everywhere", "~> 1.0"
 end
 
 appraise 'rails_5.2' do
@@ -56,7 +56,7 @@ appraise 'rails_5.2' do
   gem 'dynamoid', '~>2.2', platforms: :ruby
   gem 'aws-sdk', '~>2', platforms: :ruby
   gem 'redis-objects'
-  gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+  gem "after_commit_everywhere", "~> 1.0"
 end
 
 appraise 'norails' do

--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ end
 AASM comes with support for ActiveRecord and allows automatic persisting of the object's
 state in the database.
 
-Add `gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'` to your Gemfile 
+Add `gem 'after_commit_everywhere', '~> 1.0'` to your Gemfile.
 
 ```ruby
 class Job < ActiveRecord::Base
@@ -1028,7 +1028,7 @@ job.save! #notify_about_running_job is not run
 Please note that `:after_commit` AASM callbacks behaves around custom implementation
 of transaction pattern rather than a real-life DB transaction. This fact still causes
 the race conditions and redundant callback calls within nested transaction. In order
-to fix that it's highly recommended to add `gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'`
+to fix that it's highly recommended to add `gem 'after_commit_everywhere', '~> 1.0'`
 to your `Gemfile`.
 
 If you want to encapsulate state changes within an own transaction, the behavior

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -12,6 +12,6 @@ gem "dynamoid", "~> 1", platforms: :ruby
 gem "aws-sdk", "~> 2", platforms: :ruby
 gem "redis-objects"
 gem "activerecord-jdbcsqlite3-adapter", "1.3.24", platforms: :jruby
-gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+gem "after_commit_everywhere", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_4.2_mongoid_5.gemfile
+++ b/gemfiles/rails_4.2_mongoid_5.gemfile
@@ -7,6 +7,6 @@ gem "rails", "4.2.5"
 gem "mime-types", "~> 2", platforms: [:ruby_19, :jruby]
 gem "mongoid", "~> 5.0"
 gem "activerecord-jdbcsqlite3-adapter", "1.3.24", platforms: :jruby
-gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+gem "after_commit_everywhere", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -9,6 +9,6 @@ gem "sequel"
 gem "dynamoid", "~> 1.3", platforms: :ruby
 gem "aws-sdk", "~> 2", platforms: :ruby
 gem "redis-objects"
-gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+gem "after_commit_everywhere", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -9,6 +9,6 @@ gem "sequel"
 gem "dynamoid", "~> 1.3", platforms: :ruby
 gem "aws-sdk", "~>2", platforms: :ruby
 gem "redis-objects"
-gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+gem "after_commit_everywhere", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -9,6 +9,6 @@ gem "sequel"
 gem "dynamoid", "~>2.2", platforms: :ruby
 gem "aws-sdk", "~>2", platforms: :ruby
 gem "redis-objects"
-gem "after_commit_everywhere", "~> 0.1", ">= 0.1.5"
+gem "after_commit_everywhere", "~> 1.0"
 
 gemspec path: "../"

--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -73,7 +73,7 @@ module AASM
           rescue LoadError
             warn <<-MSG
   [DEPRECATION] :after_commit AASM callback is not safe in terms of race conditions and redundant calls.
-                Please add `gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'` to your Gemfile in order to fix that.
+                Please add `gem 'after_commit_everywhere', '~> 1.0'` to your Gemfile in order to fix that.
             MSG
             yield
           end


### PR DESCRIPTION
Hi! I'm maintainer of [after_commit_everywhere](https://github.com/Envek/after_commit_everywhere) gem that is used in aasm.

Today I bumped its version from 0.1.5 to 1.0.0 without any changes in runtime code to mark the gem as stable.

I propose to also update version in the recommendation to install it. Runtime check still accepts 0.1.5 or above.

See https://github.com/Envek/after_commit_everywhere/releases/tag/v1.0.0 for details.