### PR TITLE
Create namespaced scopes

### DIFF
--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -59,7 +59,14 @@ module AASM
     # make sure to create a (named) scope for each state
     def state_with_scope(*args)
       names = state_without_scope(*args)
-      names.each { |name| create_scope(name) if create_scope?(name) }
+      names.each do |name|
+        if namespace?
+          # Create default scopes even when namespace? for backward compatibility
+          namepaced_name = "#{namespace}_#{name}"
+          create_scope(namepaced_name) if create_scope?(namepaced_name)
+        end
+        create_scope(name) if create_scope?(name)
+      end
     end
     alias_method :state_without_scope, :state
     alias_method :state, :state_with_scope

--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -60,12 +60,7 @@ module AASM
     def state_with_scope(*args)
       names = state_without_scope(*args)
       names.each do |name|
-        if namespace?
-          # Create default scopes even when namespace? for backward compatibility
-          namepaced_name = "#{namespace}_#{name}"
-          create_scope(namepaced_name) if create_scope?(namepaced_name)
-        end
-        create_scope(name) if create_scope?(name)
+        create_scopes(name)
       end
     end
     alias_method :state_without_scope, :state
@@ -78,7 +73,16 @@ module AASM
     end
 
     def create_scope(name)
-      @klass.aasm_create_scope(@name, name)
+      @klass.aasm_create_scope(@name, name) if create_scope?(name)
+    end
+
+    def create_scopes(name)
+      if namespace?
+        # Create default scopes even when namespace? for backward compatibility
+        namepaced_name = "#{namespace}_#{name}"
+        create_scope(namepaced_name)
+      end
+      create_scope(name)
     end
   end # Base
 

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -5,17 +5,10 @@ ActiveRecord::Migration.suppress_messages do
     end
   end
 
-  ActiveRecord::Migration.create_table "simple_new_dsls", :force => true do |t|
-    t.string "status"
-  end
-  ActiveRecord::Migration.create_table "multiple_simple_new_dsls", :force => true do |t|
-    t.string "status"
-  end
-  ActiveRecord::Migration.create_table "implemented_abstract_class_dsls", :force => true do |t|
-    t.string "status"
-  end
-  ActiveRecord::Migration.create_table "users", :force => true do |t|
-    t.string "status"
+  %w(simple_new_dsls multiple_simple_new_dsls implemented_abstract_class_dsls users multiple_namespaceds).each do |table_name|
+    ActiveRecord::Migration.create_table table_name, :force => true do |t|
+      t.string "status"
+    end
   end
 
   ActiveRecord::Migration.create_table "complex_active_record_examples", :force => true do |t|

--- a/spec/models/active_record/namespaced.rb
+++ b/spec/models/active_record/namespaced.rb
@@ -1,0 +1,16 @@
+class MultipleNamespaced < ActiveRecord::Base
+  include AASM
+
+  aasm(:status, namespace: :car) do
+    state :unsold, initial: true
+    state :sold
+
+    event :sell do
+      transitions from: :unsold, to: :sold
+    end
+
+    event :return do
+      transitions from: :sold, to: :unsold
+    end
+  end
+end

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -331,6 +331,23 @@ if defined?(ActiveRecord)
         expect(MultipleSimpleNewDsl.unknown_scope).to contain_exactly(dsl2)
       end
     end
+
+    context "when namespeced" do
+      it "add namespaced scopes" do
+        expect(MultipleNamespaced).to respond_to(:car_unsold)
+        expect(MultipleNamespaced).to respond_to(:car_sold)
+
+        expect(MultipleNamespaced.car_unsold.is_a?(ActiveRecord::Relation)).to be_truthy
+        expect(MultipleNamespaced.car_sold.is_a?(ActiveRecord::Relation)).to be_truthy
+      end
+      it "add unnamespaced scopes" do
+        expect(MultipleNamespaced).to respond_to(:unsold)
+        expect(MultipleNamespaced).to respond_to(:sold)
+
+        expect(MultipleNamespaced.unsold.is_a?(ActiveRecord::Relation)).to be_truthy
+        expect(MultipleNamespaced.sold.is_a?(ActiveRecord::Relation)).to be_truthy
+      end
+    end
   end # scopes
 
   describe "direct assignment" do


### PR DESCRIPTION
Closes #733 

Creates namespaced scopes when `namespace: ...` option is provided. Keeps current behaviour of creating unnamespaced scopes.

### Example
```ruby
aasm column: :final_targeting_state, namespace: :final_targeting, create_scopes: true do
  state :unstarted, initial: true
  state :started
  state :succeeded
  state :failed
end
```
creates the scopes:
- `klass.final_targeting_unstarted`
- `klass.final_targeting_started`
- `klass.final_targeting_succeeded`
- `klass.final_targeting_failed`
- `klass.unstarted`
- `klass.started`
- `klass.succeeded`
- `klass.failed`