### PR TITLE
fix: timestamp will work with named machine

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -268,7 +268,7 @@ module AASM
 
       after_all_transitions do
         if self.class.aasm(:"#{aasm_name}").state_machine.config.timestamps
-          ts_setter = "#{aasm.to_state}_at="
+          ts_setter = "#{aasm(aasm_name).to_state}_at="
           respond_to?(ts_setter) && send(ts_setter, ::Time.now)
         end
       end

--- a/spec/models/timestamps_with_named_machine_example.rb
+++ b/spec/models/timestamps_with_named_machine_example.rb
@@ -1,0 +1,13 @@
+class TimestampsWithNamedMachineExample
+  include AASM
+
+  attr_accessor :opened_at
+
+  aasm :my_state, timestamps: true do
+    state :opened
+
+    event :open do
+      transitions to: :opened
+    end
+  end
+end

--- a/spec/unit/timestamps_spec.rb
+++ b/spec/unit/timestamps_spec.rb
@@ -24,4 +24,9 @@ describe 'timestamps option' do
     object.class.aasm.state_machine.config.timestamps = true
     expect { object.open }.to change { object.opened_at }
   end
+
+  it 'calls a timestamp setter when using a named state machine' do
+    object = TimestampsWithNamedMachineExample.new
+    expect { object.open }.to change { object.opened_at }.from(nil).to(instance_of(::Time))
+  end
 end


### PR DESCRIPTION
This PR makes sure timestamps work also with named machines. Which currently is not the case.

Using timestamps on a named machine like so:

```ruby
aasm :state, timestamps: true do 
```

Will result in an error:

```ruby
AASM::UnknownStateMachineError:
       There is no state machine with the name 'default' defined in TimestampsExample!
     # ./lib/aasm/aasm.rb:70:in `aasm'
     # ./lib/aasm/base.rb:271:in `block in setup_timestamps'
```

The fix is simple, in `ts_setter = "#{aasm(aasm_name).to_state}_at="`  it was just missing the aasm_name as an argument. It missing tried to use the `default` state machine which did not exist.

Tests are updated,to use the timestamps functionality with a named machine. Let me know, if you would prefer for the test to be more explicit about what it checks.

btw: Really love the addition of timestamps, thx to @jaynetics !