### PR TITLE
Shrink gem size and export only needed files to work

### DIFF
--- a/aasm.gemspec
+++ b/aasm.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |s|
   # s.add_development_dependency 'debugger'
   s.add_development_dependency 'pry'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files         = Dir['lib/**/*', 'README.md', 'LICENSE']
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Context about the changes made https://github.com/ruby/racc/pull/161