### PR TITLE
add ruby 3.0.2 to travis-ci runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
   - 2.5.0
   - 2.6.5
   - 2.7.0
+  - 3.0.2
   - jruby-9.1.12.0
 
 services:
@@ -48,17 +49,23 @@ matrix:
   exclude:
     - rvm: 2.7.0
       gemfile: gemfiles/rails_5.2.gemfile
+    - rvm: 3.0.2
+      gemfile: gemfiles/rails_5.2.gemfile
     - rvm: 2.5.0
       gemfile: gemfiles/rails_4.2.gemfile
     - rvm: 2.6.5
       gemfile: gemfiles/rails_4.2.gemfile
     - rvm: 2.7.0
       gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 3.0.2
+      gemfile: gemfiles/rails_4.2.gemfile
     - rvm: 2.5.0
       gemfile: gemfiles/rails_4.2_mongoid_5.gemfile
     - rvm: 2.6.5
       gemfile: gemfiles/rails_4.2_mongoid_5.gemfile
     - rvm: 2.7.0
+      gemfile: gemfiles/rails_4.2_mongoid_5.gemfile
+    - rvm: 3.0.2
       gemfile: gemfiles/rails_4.2_mongoid_5.gemfile
 #    - rvm: 2.5.0
 #      gemfile: gemfiles/rails_4.2_nobrainer.gemfile


### PR DESCRIPTION
ruby 3.0 is released and the new default ruby version. Lets ran specs against this version and fix all possible upcoming bugs.