### PR TITLE
✨ Raise `AASM::UndefinedState` when calling `fire` or `fire!` with undefined event names 

### DIFF
--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -1,6 +1,5 @@
 module AASM
   class InstanceBase
-
     attr_accessor :from_state, :to_state, :current_event
 
     def initialize(instance, name=:default) # instance of the class including AASM, name of the state machine

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -92,6 +92,7 @@ module AASM
     def state_object_for_name(name)
       obj = @instance.class.aasm(@name).states.find {|s| s.name == name}
       raise AASM::UndefinedState, "State :#{name} doesn't exist" if obj.nil?
+
       obj
     end
 
@@ -115,12 +116,19 @@ module AASM
     end
 
     def fire(event_name, *args, &block)
+      event = @instance.class.aasm(@name).state_machine.events[event_name]
+      raise AASM::UndefinedState, "State :#{event_name} doesn't exist" if event.nil?
+
       @instance.send(event_name, *args, &block)
     end
 
     def fire!(event_name, *args, &block)
-      event_name = event_name.to_s.+("!").to_sym
-      @instance.send(event_name, *args, &block)
+      bang_event_name = "#{event_name}!".to_sym
+      event = @instance.class.aasm(@name).state_machine.events[event_name]
+
+      raise AASM::UndefinedState, "State :#{bang_event_name} doesn't exist" if event.nil?
+
+      @instance.send(bang_event_name, *args, &block)
     end
 
     def set_current_state_with_persistence(state)
@@ -128,6 +136,5 @@ module AASM
       self.current_state = state if save_success
       save_success
     end
-
   end
 end

--- a/spec/unit/complex_example_spec.rb
+++ b/spec/unit/complex_example_spec.rb
@@ -90,4 +90,12 @@ describe 'when being unsuspended' do
   it "should not be able to fire unknown events" do
     expect(auth.aasm.may_fire_event?(:unknown)).to be false
   end
+
+  it "should raise AASM::UndefinedState when firing unknown events" do
+    expect { auth.aasm.fire(:unknown) }.to raise_error(AASM::UndefinedState, "State :unknown doesn't exist")
+  end
+
+  it "should raise AASM::UndefinedState when firing unknown bang events" do
+    expect { auth.aasm.fire(:unknown!) }.to raise_error(AASM::UndefinedState, "State :unknown! doesn't exist")
+  end
 end


### PR DESCRIPTION
When firing events that are unknown, we should check the state machine if the events exist before doing so, otherwise we'll get a `NoMethodError`.

Note - I saw the original PR here: https://github.com/aasm/aasm/pull/639 and wanted to see if I could play around and get it to pass 🙂 Also I recently started using the gem, so I was looking for a way to learn the gem better by contributing. Let me know if this isn't correct and I'll be happy to close it 🙇🏽‍♂️ 