### PR TITLE
Prepend timestamps with namespace to avoid naming conflicts

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -55,7 +55,7 @@ module AASM
       configure :logger, Logger.new(STDERR)
 
       # setup timestamp-setting callback if enabled
-      setup_timestamps(@name)
+      setup_timestamps(@name, namespace)
 
       # make sure to raise an error if no_direct_assignment is enabled
       # and attribute is directly assigned though
@@ -263,12 +263,13 @@ module AASM
       end
     end
 
-    def setup_timestamps(aasm_name)
+    def setup_timestamps(aasm_name, namespace)
       return unless @state_machine.config.timestamps
 
       after_all_transitions do
         if self.class.aasm(:"#{aasm_name}").state_machine.config.timestamps
-          ts_setter = "#{aasm(aasm_name).to_state}_at="
+          base_setter = "#{aasm(aasm_name).to_state}_at="
+          ts_setter = !!namespace ? "#{namespace}_#{base_setter}" : base_setter
           respond_to?(ts_setter) && send(ts_setter, ::Time.now)
         end
       end

--- a/spec/models/timestamps_with_namespace_machine_example.rb
+++ b/spec/models/timestamps_with_namespace_machine_example.rb
@@ -1,0 +1,13 @@
+class TimestampsWithNamespaceMachineExample
+  include AASM
+
+  attr_accessor :new_opened_at
+
+  aasm :my_state, timestamps: true, namespace: :new do
+    state :opened
+
+    event :open do
+      transitions to: :opened
+    end
+  end
+end

--- a/spec/unit/timestamps_spec.rb
+++ b/spec/unit/timestamps_spec.rb
@@ -29,4 +29,9 @@ describe 'timestamps option' do
     object = TimestampsWithNamedMachineExample.new
     expect { object.open }.to change { object.opened_at }.from(nil).to(instance_of(::Time))
   end
+
+  it 'calls a timestamp setter based on the state name and namespace when entering a new state using a namespace state machine' do
+    object = TimestampsWithNamespaceMachineExample.new
+    expect { object.open }.to change { object.new_opened_at }.from(nil).to(instance_of(::Time))
+  end
 end


### PR DESCRIPTION
### **Context:**
A class contains two state machines that have conflicting state names and they are both using timestamps. At least one is using a namespace.

### **Actual behavior:**
The timestamp of a particular state from the first state machine will be overridden by the transition to the conflicting state of the second state machine.

### **New behavior:**
The timestamps are prepended by the namespace when provided to avoid name collision.