### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/aasm.gemspec
+++ b/aasm.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'
 
+  s.metadata = {
+    'changelog_uri' => 'https://github.com/aasm/aasm/blob/master/CHANGELOG.md'
+  }
+
   s.add_dependency 'concurrent-ruby', '~> 1.0'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
To show the link to the change log on rubygems.org