### PR TITLE
Remove internal method mention from 'Transaction support' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,12 +1012,11 @@ Since version *3.0.13* AASM supports ActiveRecord transactions. So whenever a tr
 callback or the state update fails, all changes to any database record are rolled back.
 Mongodb does not support transactions.
 
-There are currently 3 transactional callbacks that can be handled on the event, and 2 transactional callbacks for all events.
+There are currently 3 transactional callbacks that can be handled on the event, and 2 transactional callbacks for all events:
 
 ```ruby
   event           before_all_transactions
   event           before_transaction
-  event           aasm_fire_event (within transaction)
   event           after_commit (if event successful)
   event           after_transaction
   event           after_all_transactions


### PR DESCRIPTION
The way `aasm_fire_event` is currently listed kind of makes it look like a callback than can be defined, while it's not. I'm not sure if people need to be aware of `aasm_fire_event` at all.