### PR TITLE
Document current default for whiny_persistence flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ job.aasm.fire!(:run) # saved
 
 Saving includes running all validations on the `Job` class. If
 `whiny_persistence` flag is set to `true`, exception is raised in case of
-failure. If `whiny_persistence` flag is set to false, methods with a bang return
+failure. If `whiny_persistence` flag is set to `false` (default), methods with a bang return
 `true` if the state transition is successful or `false` if an error occurs.
 
 If you want make sure the state gets saved without running validations (and


### PR DESCRIPTION
As many before we have been bitten by the current default behaviour of bang events to NOT raise exceptions.
It took me quite a while to figure out why this does not work as expected as first search results only returned references which state that raising an exception has been "fixed" (for instance https://github.com/aasm/aasm/issues/262).

Only after quite a while I found out, that raising exceptions on bang events by default will only be part of aasm version 6 (https://github.com/aasm/aasm/pull/378).