### PR TITLE
Fix error message in 'interpret_state_args'

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -244,7 +244,7 @@ module AASM
       elsif args.size > 0
         [args, {}]
       else
-        raise "count not parse states: #{args}"
+        raise ArgumentError, "could not parse states: #{args}"
       end
     end
 


### PR DESCRIPTION
Recently received an error message that looked odd to me. 
Additionally, raised a specific error class. Hope that makes sense.