### PR TITLE
Fix namespaced scopes

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -40,15 +40,15 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
+        def aasm_create_scope(state_machine_name, scope_name, state)
           if ActiveRecord::VERSION::MAJOR >= 3
-            conditions = { aasm(state_machine_name).attribute_name => scope_name.to_s }
+            conditions = { aasm(state_machine_name).attribute_name => state.to_s }
             class_eval do
               scope scope_name, lambda { where(table_name => conditions) }
             end
           else
             conditions = {
-              table_name => { aasm(state_machine_name).attribute_name => scope_name.to_s }
+              table_name => { aasm(state_machine_name).attribute_name => state.to_s }
             }
             class_eval do
               named_scope scope_name, :conditions => conditions

--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -72,17 +72,17 @@ module AASM
       @state_machine.config.create_scopes && !@klass.respond_to?(name) && @klass.respond_to?(:aasm_create_scope)
     end
 
-    def create_scope(name)
-      @klass.aasm_create_scope(@name, name) if create_scope?(name)
+    def create_scope(name, state)
+      @klass.aasm_create_scope(@name, name, state) if create_scope?(name)
     end
 
     def create_scopes(name)
       if namespace?
         # Create default scopes even when namespace? for backward compatibility
         namepaced_name = "#{namespace}_#{name}"
-        create_scope(namepaced_name)
+        create_scope(namepaced_name, name)
       end
-      create_scope(name)
+      create_scope(name, name)
     end
   end # Base
 

--- a/lib/aasm/persistence/core_data_query_persistence.rb
+++ b/lib/aasm/persistence/core_data_query_persistence.rb
@@ -20,8 +20,8 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
-          scope(scope_name.to_sym, lambda { where(aasm(state_machine_name).attribute_name.to_sym).eq(scope_name.to_s) })
+        def aasm_create_scope(state_machine_name, scope_name, state)
+          scope(scope_name.to_sym, lambda { where(aasm(state_machine_name).attribute_name.to_sym).eq(state.to_s) })
         end
       end
 

--- a/lib/aasm/persistence/mongoid_persistence.rb
+++ b/lib/aasm/persistence/mongoid_persistence.rb
@@ -39,11 +39,11 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
+        def aasm_create_scope(state_machine_name, scope_name, state)
           scope_options = lambda {
             send(
               :where,
-              { aasm(state_machine_name).attribute_name.to_sym => scope_name.to_s }
+              { aasm(state_machine_name).attribute_name.to_sym => state.to_s }
             )
           }
           send(:scope, scope_name, scope_options)

--- a/lib/aasm/persistence/no_brainer_persistence.rb
+++ b/lib/aasm/persistence/no_brainer_persistence.rb
@@ -39,9 +39,9 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
+        def aasm_create_scope(state_machine_name, scope_name, state)
           scope_options = lambda {
-            where(aasm(state_machine_name).attribute_name.to_sym => scope_name.to_s)
+            where(aasm(state_machine_name).attribute_name.to_sym => state.to_s)
           }
           send(:scope, scope_name, scope_options)
         end

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -338,14 +338,18 @@ if defined?(ActiveRecord)
         expect(MultipleNamespaced).to respond_to(:car_sold)
 
         expect(MultipleNamespaced.car_unsold.is_a?(ActiveRecord::Relation)).to be_truthy
+        expect(MultipleNamespaced.car_unsold.where_values_hash.stringify_keys).to eq({ "status" => "unsold" })
         expect(MultipleNamespaced.car_sold.is_a?(ActiveRecord::Relation)).to be_truthy
+        expect(MultipleNamespaced.car_sold.where_values_hash.stringify_keys).to eq({ "status" => "sold" })
       end
       it "add unnamespaced scopes" do
         expect(MultipleNamespaced).to respond_to(:unsold)
         expect(MultipleNamespaced).to respond_to(:sold)
 
         expect(MultipleNamespaced.unsold.is_a?(ActiveRecord::Relation)).to be_truthy
+        expect(MultipleNamespaced.unsold.where_values_hash.stringify_keys).to eq({ "status" => "unsold" })
         expect(MultipleNamespaced.sold.is_a?(ActiveRecord::Relation)).to be_truthy
+        expect(MultipleNamespaced.sold.where_values_hash.stringify_keys).to eq({ "status" => "sold" })
       end
     end
   end # scopes


### PR DESCRIPTION
Scopes for namespaced machines were not working properly. The value used in the condition was not actually the state, but rather the scope's name. Example:

```
MultipleNamespaced.car_unsold # queried "state: :car_unsold" instead of "state: :unsold"
```