### PR TITLE
Add possibility to skip constant creation for each state

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -54,6 +54,9 @@ module AASM
       # Configure a logger, with default being a Logger to STDERR
       configure :logger, Logger.new(STDERR)
 
+      # Add possibility to skip state's constant creation
+      configure :create_constants, true
+
       # setup timestamp-setting callback if enabled
       setup_timestamps(@name)
 
@@ -100,9 +103,11 @@ module AASM
           aasm(aasm_name).current_state == state
         end
 
-        const_name = namespace? ? "STATE_#{namespace.upcase}_#{name.upcase}" : "STATE_#{name.upcase}"
-        unless klass.const_defined?(const_name)
-          klass.const_set(const_name, name)
+        if @state_machine.config.create_constants
+          const_name = namespace? ? "STATE_#{namespace.upcase}_#{name.upcase}" : "STATE_#{name.upcase}"
+          unless klass.const_defined?(const_name)
+            klass.const_set(const_name, name)
+          end
         end
       end
     end

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -41,6 +41,9 @@ module AASM
     # Configure a logger, with default being a Logger to STDERR
     attr_accessor :logger
 
+    # Add possibility to skip state's constant creation
+    attr_accessor :create_constants
+
     class << self
       attr_accessor :hide_warnings
     end

--- a/spec/models/no_constant.rb
+++ b/spec/models/no_constant.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NoConstant
+  include AASM
+
+  aasm create_constants: false do
+    state :initialised, initial: true
+    state :filled_out
+    state :authorised
+  end
+end

--- a/spec/unit/no_constants_spec.rb
+++ b/spec/unit/no_constants_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'No Constants' do
+  let(:simple) { NoConstant.new }
+
+  it 'defines constants for each state name' do
+    expect(NoConstant.const_defined?('STATE_INITIALISED')).to be_falsey
+    expect(NoConstant.const_defined?('STATE_FILLED_OUT')).to be_falsey
+    expect(NoConstant.const_defined?('STATE_AUTHORISED')).to be_falsey
+  end
+end


### PR DESCRIPTION
Basically simpler fix for https://github.com/aasm/aasm/pull/770

With it you may use states that have hyphen in the name without constant creation error. 