### PR TITLE
Fixed an error in Ruby 3 when specifying a method that takes keyword arguments, such as event's before hook.

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -223,7 +223,16 @@ module AASM
         end
       end
 
-      klass.send(:define_method, method_name, method_definition)
+      klass.send(:define_method, method_name, method_definition).tap do |sym|
+        if RUBY_VERSION >= '2.7.1'
+          if klass.instance_method(method_name).parameters.find { |type, _| type.to_s.start_with?('rest') }
+            # If there is a place where you are receiving in *args, do ruby2_keywords.
+            klass.module_eval do
+              ruby2_keywords sym
+            end
+          end
+        end
+      end
     end
 
     def namespace?

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -224,12 +224,16 @@ module AASM
       end
 
       klass.send(:define_method, method_name, method_definition).tap do |sym|
-        if RUBY_VERSION >= '2.7.1'
-          if klass.instance_method(method_name).parameters.find { |type, _| type.to_s.start_with?('rest') }
-            # If there is a place where you are receiving in *args, do ruby2_keywords.
-            klass.module_eval do
-              ruby2_keywords sym
-            end
+        apply_ruby2_keyword(klass, sym)
+      end
+    end
+
+    def apply_ruby2_keyword(klass, sym)
+      if RUBY_VERSION >= '2.7.1'
+        if klass.instance_method(sym).parameters.find { |type, _| type.to_s.start_with?('rest') }
+          # If there is a place where you are receiving in *args, do ruby2_keywords.
+          klass.module_eval do
+            ruby2_keywords sym
           end
         end
       end

--- a/spec/models/event_with_keyword_arguments.rb
+++ b/spec/models/event_with_keyword_arguments.rb
@@ -1,0 +1,16 @@
+class EventWithKeywordArguments
+  include AASM
+
+  aasm do
+    state :open, :initial => true, :column => :status
+    state :closed
+
+    event :close do
+      before :_before_close
+      transitions from: :open, to: :closed
+    end
+  end
+
+  def _before_close(key:)
+  end
+end

--- a/spec/unit/event_with_keyword_arguments_spec.rb
+++ b/spec/unit/event_with_keyword_arguments_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe EventWithKeywordArguments do
+  let(:example) { EventWithKeywordArguments.new }
+  describe 'enable keyword arguments' do
+    it 'should be executed correctly that method registered by "before hooks" for events with keyword arguments.' do
+      expect(example.close(key: 1)).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
In Ruby 3, I get an error if I specify a method that takes a keyword argument, such as the before hook of an event.

I have fixed it.

```
1) EventWithKeywordArguments enable keyword arguments should be executed correctly that method registered by "before hooks" for events with keyword arguments.
   Failure/Error:
     def _before_close(key:)
     end

   ArgumentError:
     wrong number of arguments (given 1, expected 0; required keyword: key)
   # ./spec/models/event_with_keyword_arguments.rb:14:in `_before_close'
   # ./lib/aasm/core/invokers/literal_invoker.rb:33:in `exec_subject'
   # ./lib/aasm/core/invokers/literal_invoker.rb:19:in `invoke_subject'
   # ./lib/aasm/core/invokers/base_invoker.rb:48:in `invoke'
   # ./lib/aasm/core/invoker.rb:85:in `invoke'
   # ./lib/aasm/core/invoker.rb:107:in `sub_invoke'
   # ./lib/aasm/core/invoker.rb:100:in `block in invoke_array'
   # ./lib/aasm/core/invoker.rb:100:in `map'
   # ./lib/aasm/core/invoker.rb:100:in `invoke_array'
   # ./lib/aasm/core/invoker.rb:84:in `invoke'
   # ./lib/aasm/core/event.rb:174:in `invoke_callbacks'
   # ./lib/aasm/core/event.rb:77:in `fire_callbacks'
   # ./lib/aasm/aasm.rb:133:in `fire_default_callbacks'
   # ./lib/aasm/aasm.rb:102:in `aasm_fire_event'
   # ./lib/aasm/base.rb:131:in `block in event'
   # ./spec/unit/event_with_keyword_arguments_spec.rb:7:in `block (3 levels) in <top (required)>'
```