### PR TITLE
Fix mongoid specs by adding require in mongoid specs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
           gemfile: rails_4.2_mongoid_5
         - ruby: truffleruby
           gemfile: rails_5.2
+        - ruby: truffleruby
+          gemfile: rails_6.1
         allow_failures:
           - false
     env:

--- a/spec/spec_helpers/mongoid.rb
+++ b/spec/spec_helpers/mongoid.rb
@@ -2,6 +2,7 @@
 
 begin
   require 'mongoid'
+  require 'rails'
   puts "mongoid #{Mongoid::VERSION} gem found, running mongoid specs \e[32m#{'✔'}\e[0m"
 
   if Mongoid::VERSION.to_f <= 5


### PR DESCRIPTION
Disable truffleruby for Rails 6.1 as git workflow is not able to setup truffleruby for Rails 6.1