### PR TITLE
Cast string to symbol in fire/fire!, and fix deceptive error class and message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Allow `fire` and `fire!` to accept a String or Symbol for the event name, and raise AASM::UndefinedEvent rather than AASM::UndefinedState
+  when an event can not be found, thanks to [norman](https://github.com/norman).
+
 ## 5.3.0
 
 * Add Ruby 3.1 and Rails 7 to the CI matrix [#775](https://github.com/aasm/aasm/pull/775), thanks to [petergoldstein](https://github.com/petergoldstein)

--- a/lib/aasm/errors.rb
+++ b/lib/aasm/errors.rb
@@ -17,5 +17,6 @@ module AASM
   end
 
   class UndefinedState < RuntimeError; end
+  class UndefinedEvent < UndefinedState; end
   class NoDirectAssignmentError < RuntimeError; end
 end

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -134,7 +134,7 @@ module AASM
     private
 
     def event_exists?(event_name, bang = false)
-      event = @instance.class.aasm(@name).state_machine.events[event_name]
+      event = @instance.class.aasm(@name).state_machine.events[event_name.to_sym]
       event_error = bang ? "#{event_name}!" : event_name
 
       raise AASM::UndefinedState, "State :#{event_error} doesn't exist" if event.nil?

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -138,7 +138,7 @@ module AASM
       return true if event
 
       event_error = bang ? "#{event_name}!" : event_name
-      raise AASM::UndefinedState, "Event :#{event_error} doesn't exist" if event.nil?
+      raise AASM::UndefinedEvent, "Event :#{event_error} doesn't exist" if event.nil?
     end
   end
 end

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -135,8 +135,9 @@ module AASM
 
     def event_exists?(event_name, bang = false)
       event = @instance.class.aasm(@name).state_machine.events[event_name.to_sym]
-      event_error = bang ? "#{event_name}!" : event_name
+      return true if event
 
+      event_error = bang ? "#{event_name}!" : event_name
       raise AASM::UndefinedState, "State :#{event_error} doesn't exist" if event.nil?
     end
   end

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -138,7 +138,7 @@ module AASM
       return true if event
 
       event_error = bang ? "#{event_name}!" : event_name
-      raise AASM::UndefinedState, "State :#{event_error} doesn't exist" if event.nil?
+      raise AASM::UndefinedState, "Event :#{event_error} doesn't exist" if event.nil?
     end
   end
 end

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -153,11 +153,11 @@ describe 'callbacks for the new DSL' do
 
     expect {
       callback.aasm.fire(:unknown)
-    }.to raise_error(AASM::UndefinedState, "State :unknown doesn't exist")
+    }.to raise_error(AASM::UndefinedState, "Event :unknown doesn't exist")
 
     expect {
       callback.aasm.fire!(:unknown)
-    }.to raise_error(AASM::UndefinedState, "State :unknown! doesn't exist")
+    }.to raise_error(AASM::UndefinedState, "Event :unknown! doesn't exist")
   end
 
   it "does not run any state callback if the event guard fails" do

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -153,11 +153,11 @@ describe 'callbacks for the new DSL' do
 
     expect {
       callback.aasm.fire(:unknown)
-    }.to raise_error(AASM::UndefinedState, "Event :unknown doesn't exist")
+    }.to raise_error(AASM::UndefinedEvent, "Event :unknown doesn't exist")
 
     expect {
       callback.aasm.fire!(:unknown)
-    }.to raise_error(AASM::UndefinedState, "Event :unknown! doesn't exist")
+    }.to raise_error(AASM::UndefinedEvent, "Event :unknown! doesn't exist")
   end
 
   it "does not run any state callback if the event guard fails" do

--- a/spec/unit/complex_example_spec.rb
+++ b/spec/unit/complex_example_spec.rb
@@ -92,10 +92,10 @@ describe 'when being unsuspended' do
   end
 
   it "should raise AASM::UndefinedState when firing unknown events" do
-    expect { auth.aasm.fire(:unknown) }.to raise_error(AASM::UndefinedState, "State :unknown doesn't exist")
+    expect { auth.aasm.fire(:unknown) }.to raise_error(AASM::UndefinedState, "Event :unknown doesn't exist")
   end
 
   it "should raise AASM::UndefinedState when firing unknown bang events" do
-    expect { auth.aasm.fire!(:unknown) }.to raise_error(AASM::UndefinedState, "State :unknown! doesn't exist")
+    expect { auth.aasm.fire!(:unknown) }.to raise_error(AASM::UndefinedState, "Event :unknown! doesn't exist")
   end
 end

--- a/spec/unit/complex_example_spec.rb
+++ b/spec/unit/complex_example_spec.rb
@@ -92,10 +92,10 @@ describe 'when being unsuspended' do
   end
 
   it "should raise AASM::UndefinedState when firing unknown events" do
-    expect { auth.aasm.fire(:unknown) }.to raise_error(AASM::UndefinedState, "Event :unknown doesn't exist")
+    expect { auth.aasm.fire(:unknown) }.to raise_error(AASM::UndefinedEvent, "Event :unknown doesn't exist")
   end
 
   it "should raise AASM::UndefinedState when firing unknown bang events" do
-    expect { auth.aasm.fire!(:unknown) }.to raise_error(AASM::UndefinedState, "Event :unknown! doesn't exist")
+    expect { auth.aasm.fire!(:unknown) }.to raise_error(AASM::UndefinedEvent, "Event :unknown! doesn't exist")
   end
 end

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -296,15 +296,32 @@ describe 'current event' do
   end
 
   describe "when calling events with fire/fire!" do
-    it "fire should populate aasm.current_event and transition (sleeping to showering)" do
-      pe.aasm.fire(:wakeup)
-      expect(pe.aasm.current_event).to eq :wakeup
-      expect(pe.aasm.current_state).to eq :showering
+    context "fire" do
+      it "should populate aasm.current_event and transition (sleeping to showering)" do
+        pe.aasm.fire(:wakeup)
+        expect(pe.aasm.current_event).to eq :wakeup
+        expect(pe.aasm.current_state).to eq :showering
+      end
+
+      it "should allow event names as strings" do
+        pe.aasm.fire("wakeup")
+        expect(pe.aasm.current_event).to eq :wakeup
+        expect(pe.aasm.current_state).to eq :showering
+      end
     end
-    it "fire! should populate aasm.current_event and transition (sleeping to showering)" do
-      pe.aasm.fire!(:wakeup)
-      expect(pe.aasm.current_event).to eq :wakeup!
-      expect(pe.aasm.current_state).to eq :showering
+
+    context "fire!" do
+      it "should populate aasm.current_event and transition (sleeping to showering)" do
+        pe.aasm.fire!(:wakeup)
+        expect(pe.aasm.current_event).to eq :wakeup!
+        expect(pe.aasm.current_state).to eq :showering
+      end
+
+      it "should allow event names as strings" do
+        pe.aasm.fire!("wakeup")
+        expect(pe.aasm.current_event).to eq :wakeup!
+        expect(pe.aasm.current_state).to eq :showering
+      end
     end
   end
 end


### PR DESCRIPTION
This PR resolves #787 by making `fire` and `fire!` allow a String or Symbol argument.

I've also changed the error that is raised when these methods are passed a String or Symbol that does not refer to a known event.

At present `fire!` raises an `AASM::UndefinedState` error when an event can not be found. The error message says: `"State :#{event_error} doesn't exist"` This is confusing and arguably incorrect because the item that can not be found is not a *state*, but rather an *event*. 

If you look at the current code I think the mismatch is readily apparent:

```ruby
def event_exists?(event_name, bang = false)
  event = @instance.class.aasm(@name).state_machine.events[event_name]
  event_error = bang ? "#{event_name}!" : event_name

  raise AASM::UndefinedState, "State :#{event_error} doesn't exist" if event.nil?
end
```
To make this more transparent to users of this library, I have added an `AASM::UndefinedEvent` and changed the error message string to reflect this difference.

To retain backwards compatibility and avoid having to release the next version as`5.4.0`,  I have made `AASM::UndefinedEvent` a subclass of `AASM::UndefinedState`. Applications that already count on rescuing `AASM::UndefinedState` in this context should still work without modification.