### PR TITLE
Add from_states_for_event and to_states_for_event methods

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -187,11 +187,18 @@ module AASM
       states.map { |state| state.for_select }
     end
 
+    def from_states_for_event(event)
+      @state_machine.events[event].transitions.map { |t| t.from }.flatten.uniq
+    end
+
+    def to_states_for_event(event)
+      @state_machine.events[event].transitions.map { |t| t.to }.flatten.uniq
+    end
+
     def from_states_for_state(state, options={})
       if options[:transition]
         @state_machine.events[options[:transition]].transitions_to_state(state).flatten.map(&:from).flatten
       else
-
         events.map {|e| e.transitions_to_state(state)}.flatten.map(&:from).flatten
       end
     end

--- a/spec/unit/inspection_spec.rb
+++ b/spec/unit/inspection_spec.rb
@@ -125,6 +125,33 @@ describe 'aasm.from_states_for_state' do
   end
 end
 
+describe "aasm.from_states_for_event" do
+  it "should be callable" do
+    expect(SimpleExample.aasm).to respond_to(:from_states_for_event)
+  end
+
+  it "should return all from states (flattened)" do
+    froms = ComplexExample.aasm.from_states_for_event(:suspend)
+    [:passive, :pending, :active].each {|from| expect(froms).to include(from)}
+  end
+
+  it "should return all from states for any transitions on an event" do
+    froms = ParametrisedEvent.aasm.from_states_for_event(:dress)
+    [:sleeping, :showering].each {|from| expect(froms).to include(from)}
+  end
+end
+
+describe "aasm.to_states_for_event" do
+  it "should be callable" do
+    expect(SimpleExample.aasm).to respond_to(:to_states_for_event)
+  end
+
+  it "should return all to states for any transitions on an event" do
+    to_states = ParametrisedEvent.aasm.to_states_for_event(:dress)
+    [:working, :dating, :prettying_up].each {|to| expect(to_states).to include(to)}
+  end
+end
+
 describe 'permitted events' do
   let(:foo) {Foo.new}
 


### PR DESCRIPTION
Hi, I'm new to AASM and just recently started using it.
### What does this do?
- Add `from_states_for_event` method to `AASM::Base`
- Add `to_states_for_event` method to `AASM::Base`
- Add respective unit tests

### Use case
In my case, I want to create a message indicating which states an object must be in to progress to another state. I ended up writing the code for `from_states_for_event` and figured it would be nice to have it as an integrated helper.

`to_states_for_event` is included as a bonus.

### Specs passing?
Yes. I ran them all with `docker-compose` as suggested--except for the rails 4.2 ones due to bundler issues. Also, I had to make a couple small changes to `Dockerfile` and `docker-compose.yml` to get them to run on the `arm64v8` architecture. These changes are not included with the PR.