### PR TITLE
Replace `File.exists?` with `File.exist?`

### DIFF
--- a/lib/generators/aasm/orm_helpers.rb
+++ b/lib/generators/aasm/orm_helpers.rb
@@ -29,7 +29,7 @@ RUBY
       end
 
       def model_exists?
-        File.exists?(File.join(destination_root, model_path))
+        File.exist?(File.join(destination_root, model_path))
       end
 
       def model_path


### PR DESCRIPTION
`File.exists?` will be removed in Ruby 3.2.

https://www.ruby-lang.org/en/news/2022/11/11/ruby-3-2-0-preview3-released/