### PR TITLE
Toggle 'STATE_' on autogenerated constants

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -51,6 +51,9 @@ module AASM
       # Set to true to namespace reader methods and constants
       configure :namespace, false
 
+      # Set to true to prefix reader constants
+      configure :prefix_constants, true
+
       # Configure a logger, with default being a Logger to STDERR
       configure :logger, Logger.new(STDERR)
 
@@ -100,7 +103,9 @@ module AASM
           aasm(aasm_name).current_state == state
         end
 
-        const_name = namespace? ? "STATE_#{namespace.upcase}_#{name.upcase}" : "STATE_#{name.upcase}"
+        const_name = namespace? ? "#{namespace.upcase}_#{name.upcase}" : "#{name.upcase}"
+        const_name = prefix_constants? ? "STATE_#{const_name}" : const_name
+
         unless klass.const_defined?(const_name)
           klass.const_set(const_name, name)
         end
@@ -237,6 +242,10 @@ module AASM
           end
         end
       end
+    end
+
+    def prefix_constants?
+      !!@state_machine.config.prefix_constants
     end
 
     def namespace?

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -38,6 +38,9 @@ module AASM
     # namespace reader methods and constants
     attr_accessor :namespace
 
+    # prefix_constants reader
+    attr_accessor :prefix_constants
+
     # Configure a logger, with default being a Logger to STDERR
     attr_accessor :logger
 

--- a/spec/models/simple_example_without_prefix_constants.rb
+++ b/spec/models/simple_example_without_prefix_constants.rb
@@ -1,0 +1,21 @@
+class SimpleWithoutPrefixConstantsExample
+  include AASM
+  aasm prefix_constants: false do
+    state :initialised, :initial => true
+    state :filled_out
+    state :denied
+    state :authorised
+
+    event :fill_out do
+      transitions :from => :initialised, :to => :filled_out
+    end
+
+    event :deny do
+      transitions from: :initialised, to: :denied
+    end
+
+    event :authorise do
+      transitions :from => :filled_out, :to => :authorised
+    end
+  end
+end

--- a/spec/unit/simple_example_without_prefix_constants_spec.rb
+++ b/spec/unit/simple_example_without_prefix_constants_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'state machine' do
+  let(:simple) { SimpleWithoutPrefixConstantsExample.new }
+
+  it 'starts with an initial state' do
+    expect(simple.aasm.current_state).to eq(:initialised)
+    expect(simple).to respond_to(:initialised?)
+    expect(simple).to be_initialised
+  end
+
+  it 'allows transitions to other states' do
+    expect(simple).to respond_to(:fill_out)
+    expect(simple).to respond_to(:fill_out!)
+    simple.fill_out!
+    expect(simple).to respond_to(:filled_out?)
+    expect(simple).to be_filled_out
+
+    expect(simple).to respond_to(:authorise)
+    expect(simple).to respond_to(:authorise!)
+    simple.authorise
+    expect(simple).to respond_to(:authorised?)
+    expect(simple).to be_authorised
+  end
+
+  it 'shows the permitted transitions' do
+    expect(simple.aasm.permitted_transitions).to eq(
+      [
+        { event: :fill_out, state: :filled_out },
+        { event: :deny, state: :denied }
+      ]
+    )
+
+    simple.fill_out!
+    expect(simple.aasm.permitted_transitions).to eq([{ event: :authorise, state: :authorised }])
+
+    simple.authorise
+    expect(simple.aasm.permitted_transitions).to eq([])
+  end
+
+  it 'denies transitions to other states' do
+    expect {simple.authorise}.to raise_error(AASM::InvalidTransition)
+    expect {simple.authorise!}.to raise_error(AASM::InvalidTransition)
+    simple.fill_out
+    expect {simple.fill_out}.to raise_error(AASM::InvalidTransition)
+    expect {simple.fill_out!}.to raise_error(AASM::InvalidTransition)
+    simple.authorise
+    expect {simple.fill_out}.to raise_error(AASM::InvalidTransition)
+    expect {simple.fill_out!}.to raise_error(AASM::InvalidTransition)
+  end
+
+  it 'defines constants for each state name' do
+    expect(SimpleWithoutPrefixConstantsExample::INITIALISED).to eq(:initialised)
+    expect(SimpleWithoutPrefixConstantsExample::FILLED_OUT).to eq(:filled_out)
+    expect(SimpleWithoutPrefixConstantsExample::AUTHORISED).to eq(:authorised)
+  end
+end


### PR DESCRIPTION
Allow users of the gem to turn off the prefix on autogenerated constants so one could use SimpleExample::INSTANTIATED instead of SimpleExample::STATE_INSTANTIATED as it seems more natural.