### PR TITLE
Allow subclassing AASM core classes

### DIFF
--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -10,6 +10,7 @@ module AASM
       @name = name
       # @state_machine = klass.aasm(@name).state_machine
       @state_machine = state_machine
+      @state_machine.implementation = self
       @state_machine.config.column ||= (options[:column] || default_column).to_sym
       # @state_machine.config.column = options[:column].to_sym if options[:column] # master
       @options = options
@@ -194,6 +195,18 @@ module AASM
 
         events.map {|e| e.transitions_to_state(state)}.flatten.map(&:from).flatten
       end
+    end
+
+    def aasm_state_class
+      AASM::Core::State
+    end
+
+    def aasm_event_class
+      AASM::Core::Event
+    end
+
+    def aasm_transition_class
+      AASM::Core::Transition
     end
 
     private

--- a/lib/aasm/core/transition.rb
+++ b/lib/aasm/core/transition.rb
@@ -8,7 +8,7 @@ module AASM::Core
     alias_method :options, :opts
 
     def initialize(event, opts, &block)
-      add_options_from_dsl(opts, [:on_transition, :guard, :after, :success], &block) if block
+      add_options_from_dsl(opts, dsl_option_keys, &block) if block
 
       @event = event
       @from = opts[:from]
@@ -79,5 +79,8 @@ module AASM::Core
       Invoker.new(code, record, args).invoke
     end
 
+    def dsl_option_keys
+      [:on_transition, :guard, :after, :success]
+    end
   end
 end # AASM

--- a/lib/aasm/state_machine.rb
+++ b/lib/aasm/state_machine.rb
@@ -2,7 +2,7 @@ module AASM
   class StateMachine
     # the following four methods provide the storage of all state machines
 
-    attr_accessor :states, :events, :initial_state, :config, :name, :global_callbacks
+    attr_accessor :states, :events, :initial_state, :config, :name, :implementation, :global_callbacks
 
     def initialize(name)
       @initial_state = nil
@@ -28,11 +28,15 @@ module AASM
       # allow reloading, extending or redefining a state
       @states.delete(state_name) if @states.include?(state_name)
 
-      @states << AASM::Core::State.new(state_name, klass, self, options)
+      state_class = implementation.aasm_state_class
+      raise ArgumentError, "The class #{state_class} must inherit from AASM::Core::State!" unless state_class.ancestors.include?(AASM::Core::State)
+      @states << state_class.new(state_name, klass, self, options)
     end
 
     def add_event(name, options, &block)
-      @events[name] = AASM::Core::Event.new(name, self, options, &block)
+      event_class = implementation.aasm_event_class
+      raise ArgumentError, "The class #{event_class} must inherit from AASM::Core::Event!" unless event_class.ancestors.include?(AASM::Core::Event)
+      @events[name] = event_class.new(name, self, options, &block)
     end
 
     def add_global_callbacks(name, *callbacks, &block)

--- a/spec/models/custom_aasm_base.rb
+++ b/spec/models/custom_aasm_base.rb
@@ -1,0 +1,14 @@
+class CustomAasmBase < AASM::Base
+
+  def aasm_state_class
+    CustomState
+  end
+
+  def aasm_event_class
+    CustomEvent
+  end
+
+  def aasm_transition_class
+    CustomTransition
+  end
+end

--- a/spec/models/custom_event.rb
+++ b/spec/models/custom_event.rb
@@ -1,0 +1,21 @@
+class CustomEvent < AASM::Core::Event
+  attr_reader :custom_method_args
+
+  def custom_event_method!(value)
+    @custom_method_args = value
+  end
+
+  def some_option
+    options[:some_option]
+  end
+
+  def another_option
+    options[:another_option]
+  end
+
+  private
+
+  def dsl_option_keys
+    super + [:some_option, :another_option]
+  end
+end

--- a/spec/models/custom_state.rb
+++ b/spec/models/custom_state.rb
@@ -1,0 +1,6 @@
+class CustomState < AASM::Core::State
+
+  def custom_state_method(value)
+    value * value
+  end
+end

--- a/spec/models/custom_transition.rb
+++ b/spec/models/custom_transition.rb
@@ -1,0 +1,21 @@
+class CustomTransition < AASM::Core::Transition
+  attr_reader :custom_method_args
+
+  def custom_transition_method!(value)
+    @custom_method_args = value
+  end
+
+  def some_option
+    opts[:some_option]
+  end
+
+  def another_option
+    options[:another_option]
+  end
+
+  private
+
+  def dsl_option_keys
+    super + [:some_option, :another_option]
+  end
+end

--- a/spec/models/full_example_with_custom_aasm_base.rb
+++ b/spec/models/full_example_with_custom_aasm_base.rb
@@ -1,0 +1,18 @@
+class FullExampleWithCustomAasmBase
+  include AASM
+
+  aasm with_klass: CustomAasmBase do
+    state :initialised, :initial => true
+    state :filled_out
+
+    event :fill_out, :some_option => '-- some event value --' do
+      another_option '-- another event value --'
+      custom_event_method!(41)
+
+      transitions :from => :initialised, :to => :filled_out, :some_option => '-- some transition value --' do
+        another_option '-- another transition value --'
+        custom_transition_method! 42
+      end
+    end
+  end
+end

--- a/spec/models/real_world_example_with_custom_aasm_base.rb
+++ b/spec/models/real_world_example_with_custom_aasm_base.rb
@@ -1,0 +1,26 @@
+class RealWorldExampleWithCustomAasmBase
+  include AASM
+
+  class RequiredParamsEvent < AASM::Core::Event
+    def required_params!(*keys)
+      options[:before] ||= []
+      options[:before] << ->(**args) do
+        missing = keys - args.keys
+        raise ArgumentError, "Missing required arguments #{missing.inspect}" unless missing == []
+      end
+    end
+  end
+  class RequiredParams < AASM::Base
+    def aasm_event_class; RequiredParamsEvent; end
+  end
+
+  aasm with_klass: RequiredParams do
+    state :initialised, :initial => true
+    state :filled_out
+
+    event :fill_out do
+      required_params! :user, :quantity, :date
+      transitions :from => :initialised, :to => :filled_out
+    end
+  end
+end

--- a/spec/models/simple_example_with_custom_aasm_base.rb
+++ b/spec/models/simple_example_with_custom_aasm_base.rb
@@ -1,0 +1,12 @@
+class SimpleExampleWithCustomAasmBase
+  include AASM
+
+  aasm with_klass: CustomAasmBase do
+    state :initialised, :initial => true
+    state :filled_out
+
+    event :fill_out do
+      transitions :from => :initialised, :to => :filled_out
+    end
+  end
+end

--- a/spec/unit/dsl_with_custom_aasm_base_spec.rb
+++ b/spec/unit/dsl_with_custom_aasm_base_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe "dsl with custom ASM::Base and custom core classes" do
+
+  let(:example) {FullExampleWithCustomAasmBase.new}
+
+  it 'should create the expected state machine' do
+    aasm = example.aasm(:default)
+
+    state = aasm.states.first
+    expect(state).to be_a(CustomState)
+
+    event = aasm.events.first
+    expect(event).to be_a(CustomEvent)
+    expect(event.some_option).to eq('-- some event value --')
+    expect(event.another_option).to eq(['-- another event value --'])
+    expect(event.custom_method_args).to eq(41)
+
+    transition = event.transitions.first
+    expect(transition).to be_a(CustomTransition)
+    expect(transition.some_option).to eq('-- some transition value --')
+    expect(transition.another_option).to eq(['-- another transition value --'])
+    expect(transition.custom_method_args).to eq(42)
+  end
+
+end

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'adding an event' do
-  let(:state_machine) { AASM::StateMachine.new(:name) }
+  let(:state_machine) { AASM::StateMachine.new(:name).tap { |sm| AASM::Base.new(nil, :name, sm) } }
   let(:event) do
     AASM::Core::Event.new(:close_order, state_machine, {:success => :success_callback}) do
       before :before_callback
@@ -36,7 +36,7 @@ describe 'adding an event' do
 end
 
 describe 'transition inspection' do
-  let(:state_machine) { AASM::StateMachine.new(:name) }
+  let(:state_machine) { AASM::StateMachine.new(:name).tap { |sm| AASM::Base.new(nil, :name, sm) } }
   let(:event) do
     AASM::Core::Event.new(:run, state_machine) do
       transitions :to => :running, :from => :sleeping
@@ -61,7 +61,7 @@ describe 'transition inspection' do
 end
 
 describe 'transition inspection without from' do
-  let(:state_machine) { AASM::StateMachine.new(:name) }
+  let(:state_machine) { AASM::StateMachine.new(:name).tap { |sm| AASM::Base.new(nil, :name, sm) } }
   let(:event) do
     AASM::Core::Event.new(:run, state_machine) do
       transitions :to => :running
@@ -79,7 +79,7 @@ describe 'transition inspection without from' do
 end
 
 describe 'firing an event' do
-  let(:state_machine) { AASM::StateMachine.new(:name) }
+  let(:state_machine) { AASM::StateMachine.new(:name).tap { |sm| AASM::Base.new(nil, :name, sm) } }
 
   it 'should return nil if the transitions are empty' do
     obj = double('object', :aasm => double('aasm', :current_state => 'open'))

--- a/spec/unit/event_subclasses_spec.rb
+++ b/spec/unit/event_subclasses_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'customized event classes' do
+  let(:state_machine) { AASM::StateMachine.new(:name).tap { |sm| CustomAasmBase.new(nil, :name, sm) } }
+
+  it 'should allow custom transition options' do
+    opts = {:some_option => '-- some value --'}
+    event = CustomEvent.new(:event_name, state_machine, opts)
+
+    expect(event.some_option).to eq('-- some value --')
+  end
+
+  it 'should set custom transition options from the dsl' do
+    opts = { }
+    event = CustomEvent.new(:event_name, state_machine, opts) do
+      some_option '-- another value --'
+    end
+
+    expect(event.some_option).to eq(['-- another value --'])
+  end
+
+  it 'should allow custom transition methods' do
+    opts = { }
+    event = CustomEvent.new(:event_name, state_machine, opts) do
+      custom_event_method!(42)
+    end
+
+    expect(event.custom_method_args).to eq(42)
+  end
+end
+
+describe 'customized transition classes' do
+  let(:state_machine) { AASM::StateMachine.new(:name).tap { |sm| CustomAasmBase.new(nil, :name, sm) } }
+  let(:event) do
+    AASM::Core::Event.new(:event_name, state_machine) do
+      transitions :to => :closed, :from => [:open, :received], success: [:transition_success_callback]
+    end
+  end
+
+  it 'should use a subclass of transition' do
+    transitions = event.transitions
+    expect(transitions.first).to be_a(CustomTransition)
+  end
+end

--- a/spec/unit/real_world_example_with_custom_aasm_base_spec.rb
+++ b/spec/unit/real_world_example_with_custom_aasm_base_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe "real world example suing ASM::Base and custom core classes" do
+
+  let(:example) {RealWorldExampleWithCustomAasmBase.new}
+
+  it 'should succeed with the correct parameters' do
+    expect { example.fill_out(:user => 1, :quantity => 3, :date => Date.today) }.not_to raise_exception
+  end
+
+  it 'should raise an exception if the correct parameters are not given' do
+    expect { example.fill_out(:user => 1) }.to raise_exception(ArgumentError, 'Missing required arguments [:quantity, :date]')
+  end
+end

--- a/spec/unit/state_subclasses_spec.rb
+++ b/spec/unit/state_subclasses_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'customized event classes' do
+  let(:example) { SimpleExampleWithCustomAasmBase.new }
+
+  it 'should create custom state classes' do
+    state = example.aasm(:default).states.first
+
+    expect(state).to be_a(CustomState)
+    expect(state.custom_state_method(7)).to eq(49)
+  end
+end

--- a/spec/unit/transition_subclass_spec.rb
+++ b/spec/unit/transition_subclass_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'custom transition sublasses do' do
+  let(:state_machine) { AASM::StateMachine.new(:name) }
+  let(:event) { AASM::Core::Event.new(:event, state_machine) }
+
+  it 'should allow custom transition options' do
+    opts = {:from => 'foo', :to => 'bar', :some_option => '-- some value --'}
+    transition = CustomTransition.new(event, opts)
+
+    expect(transition.some_option).to eq('-- some value --')
+  end
+
+  it 'should set custom transition options from the dsl' do
+    opts = {:from => 'foo', :to => 'bar'}
+    transition = CustomTransition.new(event, opts) do
+      some_option '-- another value --'
+    end
+
+    expect(transition.some_option).to eq(['-- another value --'])
+  end
+
+  it 'should allow custom transition methods' do
+    opts = {:from => 'foo', :to => 'bar'}
+    transition = CustomTransition.new(event, opts) do
+      custom_transition_method!(42)
+    end
+
+    expect(transition.custom_method_args).to eq(42)
+  end
+end


### PR DESCRIPTION
This change makes it possible to use custom sub-classes of the core, Transaction, Event and State classes.

This makes it possible to add to the DSL, for example:
```
  class AasmWithRequiredParams < AASM::Base
    class CustomEvent < AASM::Core::Event
      def required_params!(*keys)
        options[:before] ||= []
        options[:before] << ->(**args) do
          missing = keys - args.keys
          raise ArgumentError, "Missing required arguments #{missing.inspect}" unless missing == []
        end
      end
    end
  
    def aasm_event_class; RequiredParamsEvent; end
  end

  aasm with_klass: AasmWithRequiredParams do
    state :initialised, :initial => true
    state :filled_out

    event :fill_out do
      required_params! :user, :quantity
      transitions :from => :initialised, :to => :filled_out
    end
  end
```

With this DSL
`instance.fill_out(user: 1, quantity: 3)`
will succeed, but 
`instance.fill_out(user: 1)`
will raise an exception