### PR TITLE
Fixes #822 - Namespaced scopes perform incorrect queries

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -40,15 +40,15 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
+        def aasm_create_scope(state_machine_name, scope_name, state_name)
           if ActiveRecord::VERSION::MAJOR >= 3
-            conditions = { aasm(state_machine_name).attribute_name => scope_name.to_s }
+            conditions = { aasm(state_machine_name).attribute_name => state_name.to_s }
             class_eval do
               scope scope_name, lambda { where(table_name => conditions) }
             end
           else
             conditions = {
-              table_name => { aasm(state_machine_name).attribute_name => scope_name.to_s }
+              table_name => { aasm(state_machine_name).attribute_name => state_name.to_s }
             }
             class_eval do
               named_scope scope_name, :conditions => conditions

--- a/lib/aasm/persistence/base.rb
+++ b/lib/aasm/persistence/base.rb
@@ -59,9 +59,7 @@ module AASM
     # make sure to create a (named) scope for each state
     def state_with_scope(*args)
       names = state_without_scope(*args)
-      names.each do |name|
-        create_scopes(name)
-      end
+      names.each { |name| create_scopes(name) }
     end
     alias_method :state_without_scope, :state
     alias_method :state, :state_with_scope
@@ -72,17 +70,13 @@ module AASM
       @state_machine.config.create_scopes && !@klass.respond_to?(name) && @klass.respond_to?(:aasm_create_scope)
     end
 
-    def create_scope(name)
-      @klass.aasm_create_scope(@name, name) if create_scope?(name)
+    def create_scope(scope_name, state_name)
+      @klass.aasm_create_scope(@name, scope_name, state_name) if create_scope?(scope_name)
     end
 
     def create_scopes(name)
-      if namespace?
-        # Create default scopes even when namespace? for backward compatibility
-        namepaced_name = "#{namespace}_#{name}"
-        create_scope(namepaced_name)
-      end
-      create_scope(name)
+      create_scope("#{namespace}_#{name}", name) if namespace?
+      create_scope(name, name) # Create default scopes even when namespace? for backward compatibility
     end
   end # Base
 

--- a/lib/aasm/persistence/core_data_query_persistence.rb
+++ b/lib/aasm/persistence/core_data_query_persistence.rb
@@ -20,8 +20,8 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
-          scope(scope_name.to_sym, lambda { where(aasm(state_machine_name).attribute_name.to_sym).eq(scope_name.to_s) })
+        def aasm_create_scope(state_machine_name, scope_name, state_name)
+          scope(scope_name.to_sym, lambda { where(aasm(state_machine_name).attribute_name.to_sym).eq(state_name.to_s) })
         end
       end
 

--- a/lib/aasm/persistence/mongoid_persistence.rb
+++ b/lib/aasm/persistence/mongoid_persistence.rb
@@ -39,11 +39,11 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
+        def aasm_create_scope(state_machine_name, scope_name, state_name)
           scope_options = lambda {
             send(
               :where,
-              { aasm(state_machine_name).attribute_name.to_sym => scope_name.to_s }
+              { aasm(state_machine_name).attribute_name.to_sym => state_name.to_s }
             )
           }
           send(:scope, scope_name, scope_options)

--- a/lib/aasm/persistence/no_brainer_persistence.rb
+++ b/lib/aasm/persistence/no_brainer_persistence.rb
@@ -39,9 +39,9 @@ module AASM
       end
 
       module ClassMethods
-        def aasm_create_scope(state_machine_name, scope_name)
+        def aasm_create_scope(state_machine_name, scope_name, state_name)
           scope_options = lambda {
-            where(aasm(state_machine_name).attribute_name.to_sym => scope_name.to_s)
+            where(aasm(state_machine_name).attribute_name.to_sym => state_name.to_s)
           }
           send(:scope, scope_name, scope_options)
         end

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -332,7 +332,7 @@ if defined?(ActiveRecord)
       end
     end
 
-    context "when namespeced" do
+    context "when namespaced" do
       it "add namespaced scopes" do
         expect(MultipleNamespaced).to respond_to(:car_unsold)
         expect(MultipleNamespaced).to respond_to(:car_sold)
@@ -346,6 +346,10 @@ if defined?(ActiveRecord)
 
         expect(MultipleNamespaced.unsold.is_a?(ActiveRecord::Relation)).to be_truthy
         expect(MultipleNamespaced.sold.is_a?(ActiveRecord::Relation)).to be_truthy
+      end
+      it "creates identical queries" do
+        expect(MultipleNamespaced.car_unsold.all.to_sql == MultipleNamespaced.unsold.all.to_sql).to be_truthy
+        expect(MultipleNamespaced.car_sold.all.to_sql == MultipleNamespaced.sold.all.to_sql).to be_truthy
       end
     end
   end # scopes


### PR DESCRIPTION
Namespaced scopes were prepending the namespace to the state name when performing the query. This is wrong. The fix is to pass the scope name and the state name as separate arguments to `aasm_create_scope`.