### PR TITLE
Restores DIRTY changes information when updating an attribute with ActiveRecordPersistence

### DIFF
--- a/lib/aasm/persistence/active_record_persistence.rb
+++ b/lib/aasm/persistence/active_record_persistence.rb
@@ -88,7 +88,7 @@ module AASM
         end
 
         def aasm_update_column(attribute_name, value)
-          self.class.unscoped.where(self.class.primary_key => self.id).update_all(attribute_name => value) == 1
+          self.persisted? && self.update_column(attribute_name, value)
         end
 
         def aasm_read_attribute(name)
@@ -99,6 +99,7 @@ module AASM
           write_attribute(name, value)
         end
 
+        
         def aasm_transaction(requires_new, requires_lock)
           self.class.transaction(:requires_new => requires_new) do
             lock!(requires_lock) if requires_lock

--- a/lib/aasm/persistence/orm.rb
+++ b/lib/aasm/persistence/orm.rb
@@ -16,11 +16,11 @@ module AASM
       def aasm_write_state(state, name=:default)
         attribute_name = self.class.aasm(name).attribute_name
         old_value = aasm_read_attribute(attribute_name)
-        aasm_write_state_attribute state, name
 
         success = if aasm_skipping_validations(name)
           aasm_update_column(attribute_name, aasm_raw_attribute_value(state, name))
         else
+          aasm_write_state_attribute state, name
           aasm_save
         end
 

--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -152,17 +152,10 @@ if defined?(ActiveRecord)
           end
 
           it "passes state code instead of state symbol to update_all" do
-            # stub_chain does not allow us to give expectations on call
-            # parameters in the middle of the chain, so we need to use
-            # intermediate object instead.
-            obj = double(Object, update_all: 1)
-            allow(MultipleGate).to receive_message_chain(:unscoped, :where)
-              .and_return(obj)
-
+            allow(gate).to receive(:update_column).and_return(true)
+            allow(gate).to receive(:persisted?).and_return(true)
             gate.aasm_write_state state_sym, :left
-
-            expect(obj).to have_received(:update_all)
-              .with(Hash[gate.class.aasm(:left).attribute_name, state_code])
+            expect(gate).to have_received(:update_column).with(gate.class.aasm(:left).attribute_name, state_code)
           end
         end
 

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -152,36 +152,12 @@ if defined?(ActiveRecord)
           end
 
           it "passes state code instead of state symbol to update_all" do
-            # stub_chain does not allow us to give expectations on call
-            # parameters in the middle of the chain, so we need to use
-            # intermediate object instead.
-            obj = double(Object, update_all: 1)
-            allow(Gate).to receive_message_chain(:unscoped, :where).and_return(obj)
-
+            allow(gate).to receive(:update_column).and_return(true)
+            allow(gate).to receive(:persisted?).and_return(true)
             gate.aasm_write_state state_sym
-
-            expect(obj).to have_received(:update_all)
-              .with(Hash[gate.class.aasm.attribute_name, state_code])
+            expect(gate).to have_received(:update_column).with(gate.class.aasm.attribute_name, state_code)
           end
 
-          it "searches model outside of default_scope when update_all" do
-            # stub_chain does not allow us to give expectations on call
-            # parameters in the middle of the chain, so we need to use
-            # intermediate object instead.
-            unscoped = double(Object, update_all: 1)
-            scoped = double(Object, update_all: 1)
-
-            allow(Gate).to receive(:unscoped).and_return(unscoped)
-            allow(Gate).to receive(:where).and_return(scoped)
-            allow(unscoped).to receive(:where).and_return(unscoped)
-
-            gate.aasm_write_state state_sym
-
-            expect(unscoped).to have_received(:update_all)
-              .with(Hash[gate.class.aasm.attribute_name, state_code])
-            expect(scoped).to_not have_received(:update_all)
-              .with(Hash[gate.class.aasm.attribute_name, state_code])
-          end
         end
 
         context "when AASM is not skipping validations" do
@@ -487,6 +463,14 @@ if defined?(ActiveRecord)
       persistor.reload
       expect(persistor).to be_running
       expect(persistor).not_to be_sleeping
+    end
+
+    it 'should restore DIRTY changes information when updating an attribute' do
+      object = InvalidPersistor.create(name: 'name')
+      expect(object).to be_sleeping
+      object.run!
+      expect(object).to be_running
+      expect(object.changes).not_to have_key(:status)
     end
 
     describe 'pessimistic locking' do


### PR DESCRIPTION
Hi!

I would like AR DIRTY changes information to be cleared after updating a column with the bang method of an event.

In this PR I remove the status key from the DIRTY changes hash.

I also noticed that we were updating the attributes with an `update_all`. Is there any reason for this? I feel that `obj.update_column` is easier (and AR will automatically update the in-memory object).

If we don't want to use `update_column` for any reason, we could use `update_all`, and then call `self.clear_attribute_changes([attribute_name])`