### PR TITLE
Ensure that from_state is set after successfully firing an event.

### DIFF
--- a/lib/aasm/aasm.rb
+++ b/lib/aasm/aasm.rb
@@ -185,6 +185,7 @@ private
         *process_args(event, old_state.name, *args)
       )
 
+      aasm(state_machine_name).from_state = old_state
       self.aasm_event_fired(event.name, old_state.name, aasm(state_machine_name).current_state) if self.respond_to?(:aasm_event_fired)
     else
       self.aasm_event_failed(event.name, old_state.name) if self.respond_to?(:aasm_event_failed)

--- a/lib/aasm/core/event.rb
+++ b/lib/aasm/core/event.rb
@@ -142,7 +142,7 @@ module AASM::Core
         args.unshift(to_state)
         to_state = nil
       end
-      
+
       # nop, to_state is a valid to-state
 
       transitions.each do |transition|

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -276,6 +276,23 @@ describe 'should fire callbacks' do
     expect(model).to receive(:do_something_after).once.ordered
     model.in_right_order!
   end
+
+  context 'with a transition from any state' do
+    it 'sets from_state' do
+      ThisNameBetterNotBeInUse.instance_eval do
+        aasm do
+          event :some_event do
+            transitions :to => :proc
+          end
+        end
+      end
+
+      model = ThisNameBetterNotBeInUse.new
+      model.some_event
+      expect(model.aasm.from_state).to eq(:initial)
+    end
+  end
+
 end
 
 describe 'current event' do


### PR DESCRIPTION
Fixes #803.

I'm not sure is I'm assigning from_state in the right place. The drawback is that we are assigning it twice when the transition does include a from clause.