### PR TITLE
Allow passing an empty hash to `:after` transition methods

### DIFF
--- a/lib/aasm/core/invokers/literal_invoker.rb
+++ b/lib/aasm/core/invokers/literal_invoker.rb
@@ -31,7 +31,7 @@ module AASM
           return record.__send__(subject) if subject_arity.zero?
           return record.__send__(subject, *args) if subject_arity < 0
           req_args = args[0..(subject_arity - 1)]
-          return record.__send__(subject, **req_args[0]) if req_args[0].is_a?(Hash)
+          return record.__send__(subject, **req_args[0]) if req_args[0].is_a?(Hash) && !req_args[0].empty?
           record.__send__(subject, *req_args)
         end
         # rubocop:enable Metrics/AbcSize

--- a/spec/unit/rspec_matcher_spec.rb
+++ b/spec/unit/rspec_matcher_spec.rb
@@ -72,6 +72,11 @@ describe 'state machine' do
       expect(example).to_not allow_event(:fill_out_with_args).with(false)
     end
 
+    it "works with empty hash argument" do
+      pe = ParametrisedEvent.new
+      expect(pe).to transition_from(:sleeping).to(:showering).on_event(:shower, {})
+    end
+
     it "works for multiple state machines" do
       expect(multiple).to allow_event(:walk).on(:move)
       expect(multiple).to_not allow_event(:hold).on(:move)


### PR DESCRIPTION
Since Ruby 2.7, a double splat with an empty hash passes no arguments. So if an argument is an empty hash we should avoid it. 
Ref: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#other-minor-changes-empty-hash

Fix #829.