### PR TITLE
Update GitHub Actions and codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           mkdir /tmp/dynamodb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,6 @@ jobs:
       - name: Run test
         run: bundle exec rake test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false

--- a/aasm.gemspec
+++ b/aasm.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', ">= 3"
   s.add_development_dependency 'generator_spec'
   s.add_development_dependency 'appraisal'
+  s.add_development_dependency "simplecov"
   s.add_development_dependency "simplecov-cobertura"
-  s.add_development_dependency "codecov", ">= 0.1.21"
 
   # debugging
   # s.add_development_dependency 'debugger'


### PR DESCRIPTION
GitHub Actions workflow prints the following warning.

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, codecov/codecov-action@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates [actions/checkout](https://github.com/actions/checkout) and [codecov-action](https://github.com/codecov/codecov-action) to suppress it.
Also, [codecov-ruby](https://github.com/codecov/codecov-ruby) is deprecated and I followed the [migration guide](https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader) and migrated to the new uploader.
