### PR TITLE
Support rails 6.0 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,23 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         ruby: ['3.0', 2.7, 2.6, jruby-9.1.17.0, truffleruby]
-        gemfile: [norails, rails_4.2, rails_4.2_mongoid_5, rails_5.2, rails_6.1]
+        gemfile:
+          [
+            norails,
+            rails_4.2,
+            rails_4.2_mongoid_5,
+            rails_5.2,
+            rails_6.0,
+            rails_6.1,
+          ]
         redis-version: [6]
         mongodb-version: [5]
         include:
+          - ruby: '3.0'
+            gemfile: rails_6.0
+            os: ubuntu-20.04
+            redis-version: 6
+            mongodb-version: 5
           - ruby: '3.0'
             gemfile: rails_6.1
             os: ubuntu-20.04

--- a/Appraisals
+++ b/Appraisals
@@ -9,7 +9,7 @@ appraise 'rails_4.2' do
   gem 'aws-sdk', '~> 2', platforms: :ruby
   gem 'redis-objects', '1.6.0'
   gem 'activerecord-jdbcsqlite3-adapter', '1.3.24', platforms: :jruby
-  gem "after_commit_everywhere", "~> 1.0"
+  gem 'after_commit_everywhere', '~> 1.0'
 end
 
 appraise 'rails_4.2_mongoid_5' do
@@ -18,7 +18,7 @@ appraise 'rails_4.2_mongoid_5' do
   gem 'rails', '~> 4.2.11'
   gem 'mongoid', '~> 5.0'
   gem 'activerecord-jdbcsqlite3-adapter', '1.3.24', platforms: :jruby
-  gem "after_commit_everywhere", "~> 1.0"
+  gem 'after_commit_everywhere', '~> 1.0'
 end
 
 appraise 'rails_5.2' do
@@ -29,7 +29,17 @@ appraise 'rails_5.2' do
   gem 'dynamoid', '~>2.2', platforms: :ruby
   gem 'aws-sdk', '~>2', platforms: :ruby
   gem 'redis-objects', '1.6.0'
-  gem "after_commit_everywhere", "~> 1.0"
+  gem 'after_commit_everywhere', '~> 1.0'
+end
+
+appraise 'rails_6.0' do
+  gem 'rails', '~> 6.0.6.1'
+  gem 'mongoid', '~>7.0', '>= 7.0.5'
+  gem 'sequel'
+  gem 'dynamoid', '~>3.3', platforms: :ruby
+  gem 'aws-sdk-dynamodb', '~> 1'
+  gem 'redis-objects', '1.6.0'
+  gem 'after_commit_everywhere', '~> 1.0'
 end
 
 appraise 'rails_6.1' do
@@ -39,7 +49,7 @@ appraise 'rails_6.1' do
   gem 'dynamoid', '~>3.3', platforms: :ruby
   gem 'aws-sdk-dynamodb', '~> 1'
   gem 'redis-objects', '1.6.0'
-  gem "after_commit_everywhere", "~> 1.0"
+  gem 'after_commit_everywhere', '~> 1.0'
 end
 
 appraise 'norails' do
@@ -47,5 +57,5 @@ appraise 'norails' do
   gem 'rails', install_if: false
   gem 'sequel'
   gem 'redis-objects', '1.6.0'
-  gem "after_commit_everywhere", install_if: false
+  gem 'after_commit_everywhere', install_if: false
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,12 +3,12 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.4", platforms: :ruby
-gem "rails", "~> 6.0.3"
+gem "rails", "~> 6.0.6.1"
 gem "after_commit_everywhere", "~> 1.0"
 gem "mongoid", "~>7.0", ">= 7.0.5"
 gem "sequel"
 gem "dynamoid", "~>3.3", platforms: :ruby
 gem "aws-sdk-dynamodb", "~> 1"
-gem "redis-objects"
+gem "redis-objects", "1.6.0"
 
 gemspec path: "../"


### PR DESCRIPTION
5.2 is in CI, as 6.1 is. I don't see why not keep 6.0 there, either, to keep the code in check. Many companies are still migrating from 5.2 to 6.0, and then to 6.1, and this gives us the safety net we need.