### PR TITLE
Fix broken tests on Rails 7.1.2.

### DIFF
--- a/spec/unit/persistence/active_record_persistence_multiple_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_multiple_spec.rb
@@ -124,7 +124,7 @@ if defined?(ActiveRecord)
 
           it "should raise an error for transitions" do
             if ActiveRecord.gem_version >= Gem::Version.new('7.1.0')
-              expect{multiple_with_enum_without_column.send(:view, :left)}.to raise_error(RuntimeError, /Unknown enum attribute 'status'/)
+              expect{multiple_with_enum_without_column.send(:view, :left)}.to raise_error(RuntimeError, /Undeclared attribute type for enum 'status'/)
             else
               expect{multiple_with_enum_without_column.send(:view, :left)}.to raise_error(NoMethodError, /undefined method .status./)
             end

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -124,7 +124,7 @@ if defined?(ActiveRecord)
 
           it "should raise an error for transitions" do
             if ActiveRecord.gem_version >= Gem::Version.new('7.1.0')
-              expect{with_enum_without_column.send(:view)}.to raise_error(RuntimeError, /Unknown enum attribute 'status'/)
+              expect{with_enum_without_column.send(:view)}.to raise_error(RuntimeError, /Undeclared attribute type for enum 'status'/)
             else
               expect{with_enum_without_column.send(:view)}.to raise_error(NoMethodError, /undefined method .status./)
             end


### PR DESCRIPTION
The behavior of non-column-backed attributes for `enum` was changed by https://github.com/rails/rails/pull/49769.
This patch fixed the error message according to the change.