### PR TITLE
Fix keyword parameters in ruby 3.2

### DIFF
--- a/lib/aasm/core/invokers/literal_invoker.rb
+++ b/lib/aasm/core/invokers/literal_invoker.rb
@@ -31,8 +31,13 @@ module AASM
           return record.__send__(subject) if subject_arity.zero?
           return record.__send__(subject, *args) if subject_arity < 0
           req_args = args[0..(subject_arity - 1)]
-          return record.__send__(subject, **req_args[0]) if req_args[0].is_a?(Hash)
-          record.__send__(subject, *req_args)
+          if req_args[-1].is_a?(Hash)
+            positional_args = req_args[0..-2]
+            kw = req_args[-1]
+            record.__send__(subject, *positional_args, **kw)
+          else
+            record.__send__(subject, *req_args)
+          end
         end
         # rubocop:enable Metrics/AbcSize
 

--- a/spec/models/event_with_keyword_arguments.rb
+++ b/spec/models/event_with_keyword_arguments.rb
@@ -9,8 +9,16 @@ class EventWithKeywordArguments
       before :_before_close
       transitions from: :open, to: :closed
     end
+
+    event :another_close do
+      before :_before_another_close
+      transitions from: :open, to: :closed
+    end
   end
 
   def _before_close(key:)
+  end
+
+  def before_another_close(key:)
   end
 end

--- a/spec/unit/event_with_keyword_arguments_spec.rb
+++ b/spec/unit/event_with_keyword_arguments_spec.rb
@@ -6,5 +6,9 @@ describe EventWithKeywordArguments do
     it 'should be executed correctly that method registered by "before hooks" for events with keyword arguments.' do
       expect(example.close(key: 1)).to be_truthy
     end
+
+    it 'should be executed correctly that method registered by "before hooks" for events with positional and keyword arguments.' do
+      expect(example.close(1, key: 1)).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
The array argument will capture a Hash as the last entry if keywords were provided by the caller after all positional arguments.

Reference: https://docs.ruby-lang.org/en/3.2/syntax/methods_rdoc.html#label-Array-2FHash+Argument

See also #844 