### PR TITLE
Add current state detail to minitest transition_from assertions

### DIFF
--- a/lib/aasm/minitest/transition_from.rb
+++ b/lib/aasm/minitest/transition_from.rb
@@ -3,14 +3,14 @@ module Minitest::Assertions
     options = args.first
     options[:on] ||= :default
     assert _transitions_from?(object, from_state, args, options),
-          "Expected transition state to :#{options[:to]} from :#{from_state} on event :#{options[:on_event]}, (on :#{options[:on]})"
+          "Expected transition state to :#{options[:to]} from :#{from_state} on event :#{options[:on_event]}, but got :#{object.aasm(options[:on]).current_state} (on :#{options[:on]})"
   end
 
   def refute_transitions_from(object, from_state, *args)
     options = args.first
     options[:on] ||= :default
     refute _transitions_from?(object, from_state, args, options),
-          "Expected transition state to :#{options[:to]} from :#{from_state} on event :#{options[:on_event]}, (on :#{options[:on]})"
+          "Expected transition state to :#{options[:to]} from :#{from_state} on event :#{options[:on_event]}, but got :#{object.aasm(options[:on]).current_state} (on :#{options[:on]})"
   end
 
   def _transitions_from?(object, from_state, args, options)


### PR DESCRIPTION
It's useful when reviewing a failure to know which state you did get by firing the transition, not just the one you expected, as this can help with tracing down the error in the state machine. This brings the minitest helper closer to the output from the rspec version which already includes the actual state not just the expected one.