### PR TITLE
Ruby 3.2 compatibility ✅

### DIFF
--- a/lib/aasm/core/invokers/base_invoker.rb
+++ b/lib/aasm/core/invokers/base_invoker.rb
@@ -69,6 +69,16 @@ module AASM
         def invoke_subject
           raise NoMethodError, '"#invoke_subject" is not implemented'
         end
+
+        ##
+        # Parse arguments to separate keyword arguments from positional arguments
+        def parse_arguments
+          if args.last.is_a?(Hash)
+            [args[0..-2], args.last]
+          else
+            [args, nil]
+          end
+        end
       end
     end
   end

--- a/lib/aasm/core/invokers/class_invoker.rb
+++ b/lib/aasm/core/invokers/class_invoker.rb
@@ -53,18 +53,12 @@ module AASM
         end
 
         def instance_with_keyword_args
-          if args.last.is_a?(Hash)
-            new_args = args[0..-2]
-            keyword_args = args.last
-          else
-            new_args = args
-            keyword_args = nil
-          end
+          positional_args, keyword_args = parse_arguments
 
           if keyword_args.nil?
-            subject.new(record, *new_args)
+            subject.new(record, *positional_args)
           else
-            subject.new(record, *new_args, **keyword_args)
+            subject.new(record, *positional_args, **keyword_args)
           end
         end
 

--- a/lib/aasm/core/invokers/class_invoker.rb
+++ b/lib/aasm/core/invokers/class_invoker.rb
@@ -53,8 +53,13 @@ module AASM
         end
 
         def instance_with_keyword_args
-          new_args = args[0..-2]
-          keyword_args = args.last
+          if args.last.is_a?(Hash)
+            new_args = args[0..-2]
+            keyword_args = args.last
+          else
+            new_args = args
+            keyword_args = nil
+          end
 
           if keyword_args.nil?
             subject.new(record, *new_args)

--- a/lib/aasm/core/invokers/class_invoker.rb
+++ b/lib/aasm/core/invokers/class_invoker.rb
@@ -34,14 +34,38 @@ module AASM
           @instance ||= retrieve_instance
         end
 
-        # rubocop:disable Metrics/AbcSize
         def retrieve_instance
           return subject.new if subject_arity.zero?
           return subject.new(record) if subject_arity == 1
-          return subject.new(record, *args) if subject_arity < 0
+          
+          if keyword_arguments?
+            instance_with_keyword_args
+          elsif subject_arity < 0
+            subject.new(record, *args)
+          else
+            instance_with_fixed_arity
+          end
+        end
+
+        def keyword_arguments?
+          params = subject.instance_method(:initialize).parameters
+          params.any? { |type, _| [:key, :keyreq].include?(type) }
+        end
+
+        def instance_with_keyword_args
+          new_args = args[0..-2]
+          keyword_args = args.last
+
+          if keyword_args.nil?
+            subject.new(record, *new_args)
+          else
+            subject.new(record, *new_args, **keyword_args)
+          end
+        end
+
+        def instance_with_fixed_arity
           subject.new(record, *args[0..(subject_arity - 2)])
         end
-        # rubocop:enable Metrics/AbcSize
 
         def subject_arity
           @arity ||= subject.instance_method(:initialize).arity

--- a/spec/models/class_with_keyword_arguments.rb
+++ b/spec/models/class_with_keyword_arguments.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class CallbackWithOptionalKeywordArguments
+  def initialize(state_machine, my_optional_arg: nil, **_args)
+    @state_machine = state_machine
+    @my_optional_arg = my_optional_arg
+  end
+
+  def call
+    @state_machine.my_attribute = @my_optional_arg if @my_optional_arg
+  end
+end
+
+class CallbackWithRequiredKeywordArguments
+  def initialize(state_machine, my_required_arg:)
+    @state_machine = state_machine
+    @my_required_arg = my_required_arg
+  end
+
+  def call
+    @state_machine.my_attribute = @my_required_arg
+  end
+end
+
+class ClassWithKeywordArguments
+  include AASM
+  
+  aasm do
+    state :open, :initial => true, :column => :status
+    state :closed
+  
+    event :close_forever do
+      before :_before_close
+      transitions from: :open,
+                  to: :closed
+    end
+
+    event :close_temporarily do
+      before :_before_close
+      transitions from: :open,
+                  to: :closed,
+                  after: [CallbackWithOptionalKeywordArguments]
+    end
+
+    event :close_then_something_else do
+      before :_before_close
+      transitions from: :open,
+                  to: :closed,
+                  after: [CallbackWithRequiredKeywordArguments, CallbackWithRequiredKeywordArguments]
+    end
+  end
+
+
+  def _before_close
+    @my_attribute = "closed_forever"
+  end
+
+  attr_accessor :my_attribute
+end

--- a/spec/models/event_with_keyword_arguments.rb
+++ b/spec/models/event_with_keyword_arguments.rb
@@ -9,8 +9,16 @@ class EventWithKeywordArguments
       before :_before_close
       transitions from: :open, to: :closed
     end
+
+    event :another_close do
+      before :_before_another_close
+      transitions from: :open, to: :closed
+    end
   end
 
   def _before_close(key:)
+  end
+
+  def _before_another_close(foo, key: nil)
   end
 end

--- a/spec/unit/class_with_keyword_arguments_spec.rb
+++ b/spec/unit/class_with_keyword_arguments_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ClassWithKeywordArguments do
+  let(:state_machine) { ClassWithKeywordArguments.new }
+  let(:resource) { double('resource', value: 1) }
+
+  context 'when using optional keyword arguments' do
+    it 'changes state successfully to closed_temporarily' do
+      expect(state_machine.close_temporarily!(my_optional_arg: 'closed_temporarily')).to be_truthy
+      expect(state_machine.my_attribute).to eq('closed_temporarily')
+    end
+
+    it 'changes state successfully to closed_temporarily when optional keyword argument is not provided' do
+      expect(state_machine.close_temporarily!()).to be_truthy
+      expect(state_machine.my_attribute).to eq('closed_forever')
+    end
+  end
+
+  it 'changes state successfully to closed_forever' do
+    expect(state_machine.close_forever!).to be_truthy
+    expect(state_machine.my_attribute).to eq('closed_forever')
+  end 
+
+  it 'changes state successfully to closed_then_something_else' do
+    expect(state_machine.close_then_something_else!(my_required_arg: 'closed_then_something_else')).to be_truthy
+    expect(state_machine.my_attribute).to eq('closed_then_something_else')
+  end
+end

--- a/spec/unit/event_with_keyword_arguments_spec.rb
+++ b/spec/unit/event_with_keyword_arguments_spec.rb
@@ -4,7 +4,23 @@ describe EventWithKeywordArguments do
   let(:example) { EventWithKeywordArguments.new }
   describe 'enable keyword arguments' do
     it 'should be executed correctly that method registered by "before hooks" for events with keyword arguments.' do
+      expect(example).to receive(:_before_close).with(key: 1)
       expect(example.close(key: 1)).to be_truthy
+    end
+
+    it 'should be executed correctly that method registered by "before hooks" for events with keyword arguments.' do
+      expect(example).to receive(:_before_close).with(key: nil)
+      expect(example.close(key: nil)).to be_truthy
+    end
+
+    it 'should be executed correctly that method registered by "before hooks" for events with positional and keyword arguments.' do
+      expect(example).to receive(:_before_another_close).with(1, key: 2)
+      expect(example.another_close(1, key: 2)).to be_truthy
+    end
+
+    it 'should be executed correctly that method registered by "before hooks" for events with positional and keyword arguments.' do
+      expect(example).to receive(:_before_another_close).with(1, key: nil, a: 1)
+      expect(example.another_close(1, key: nil, a: 1)).to be_truthy
     end
   end
 end

--- a/spec/unit/event_with_keyword_arguments_spec.rb
+++ b/spec/unit/event_with_keyword_arguments_spec.rb
@@ -2,25 +2,32 @@ require 'spec_helper'
 
 describe EventWithKeywordArguments do
   let(:example) { EventWithKeywordArguments.new }
-  describe 'enable keyword arguments' do
-    it 'should be executed correctly that method registered by "before hooks" for events with keyword arguments.' do
-      expect(example).to receive(:_before_close).with(key: 1)
+
+  context 'when using required keyword arguments' do
+    it 'works with required keyword argument' do
       expect(example.close(key: 1)).to be_truthy
     end
 
-    it 'should be executed correctly that method registered by "before hooks" for events with keyword arguments.' do
-      expect(example).to receive(:_before_close).with(key: nil)
+    it 'works when required keyword argument is nil' do
       expect(example.close(key: nil)).to be_truthy
     end
 
-    it 'should be executed correctly that method registered by "before hooks" for events with positional and keyword arguments.' do
-      expect(example).to receive(:_before_another_close).with(1, key: 2)
+    it 'fails when the required keyword argument is not provided' do
+      expect { example.close() }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when mixing positional and keyword arguments' do
+    it 'works with defined keyword arguments' do
       expect(example.another_close(1, key: 2)).to be_truthy
     end
 
-    it 'should be executed correctly that method registered by "before hooks" for events with positional and keyword arguments.' do
-      expect(example).to receive(:_before_another_close).with(1, key: nil, a: 1)
-      expect(example.another_close(1, key: nil, a: 1)).to be_truthy
+    it 'works when optional keyword argument is nil' do
+      expect(example.another_close(1, key: nil)).to be_truthy
+    end
+
+    it 'works when optional keyword argument is not provided' do
+      expect(example.another_close(1)).to be_truthy
     end
   end
 end

--- a/spec/unit/invokers/class_invoker_spec.rb
+++ b/spec/unit/invokers/class_invoker_spec.rb
@@ -103,5 +103,24 @@ describe AASM::Core::Invokers::ClassInvoker do
         expect { subject.invoke_subject }.not_to raise_error
       end
     end
+
+    context 'when passing keyword arguments' do
+      let(:args) { [1, key: 2] }
+      let(:target) { Class.new { def initialize(record, a, key: nil); end; def call; end } }
+
+      it 'then correctly uses passed keyword arguments' do
+        expect(target).to receive(:new).with(record, 1, key: 2).and_call_original
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end
+
+    context 'when passing optional keyword arguments' do
+      let(:args) { [1, foo: 1] }
+      let(:target) { Class.new { def initialize(record, a, key: nil, foo:); end; def call; end } }
+
+      it 'then correctly uses passed keyword arguments' do
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/unit/invokers/class_invoker_spec.rb
+++ b/spec/unit/invokers/class_invoker_spec.rb
@@ -122,5 +122,14 @@ describe AASM::Core::Invokers::ClassInvoker do
         expect { subject.invoke_subject }.not_to raise_error
       end
     end
+
+    context 'when passing empty optional keyword arguments' do
+      let(:args) { [1] }
+      let(:target) { Class.new { def initialize(record, a, key: nil); end; def call; end } }
+
+      it 'then correctly uses passed keyword arguments' do
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/unit/invokers/literal_invoker_spec.rb
+++ b/spec/unit/invokers/literal_invoker_spec.rb
@@ -82,5 +82,25 @@ describe AASM::Core::Invokers::LiteralInvoker do
         expect { subject.invoke_subject }.to raise_error(NoMethodError)
       end
     end
+
+    context 'when using optional keyword arguments' do
+      let(:args) { [1] }
+      let(:record) { Class.new { def my_method(_a, key: 3); end; }.new }
+      let(:target) { :my_method}
+
+      it 'then correctly uses passed keyword arguments' do
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end
+
+    context 'when using required keyword arguments' do
+      let(:args) { [1, key: 2] }
+      let(:record) { Class.new { def my_method(_a, key:); end; }.new }
+      let(:target) { :my_method}
+
+      it 'then correctly uses passed keyword arguments' do
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end 
   end
 end


### PR DESCRIPTION
For the invoker classes, we started to rely on `.parameters` to know if there are keyword arguments. It's a clearer approach than relying on arity. I couldn't make it work by just relying on arity.

I've also improved test coverage a bit, those new test cases were all failing because of the Ruby 3.2 upgrade, so the new tests were added because of that.