### PR TITLE
Update `actions/checkout` to its latest version v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           mkdir /tmp/dynamodb


### PR DESCRIPTION
@mishina2228 had already started to look into this with https://github.com/aasm/aasm/pull/839, but the PR came with an outdated version of `codecov/codecov-action` as well. Using this isolated PR here instead.