### PR TITLE
Support per instance disabling of warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,7 +1278,7 @@ class Job
 end
 ```
 
-You can hide warnings by setting `AASM::Configuration.hide_warnings = true`
+For global disabling, use `AASM::Configuration.hide_warnings = true`. For per-instance disabling, use the `hide_warnings: true` option in the aasm method.
 
 ### RubyMotion support
 

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -54,6 +54,9 @@ module AASM
       # Configure a logger, with default being a Logger to STDERR
       configure :logger, Logger.new(STDERR)
 
+      # hide warnings
+      configure :hide_warnings, false
+
       # setup timestamp-setting callback if enabled
       setup_timestamps(@name)
 
@@ -218,7 +221,7 @@ module AASM
              klass.defined_enums.values.any?{ |methods|
                  methods.keys{| enum | enum + '?' == method_name }
              })
-        unless AASM::Configuration.hide_warnings
+        unless @state_machine.config.hide_warnings
           @state_machine.config.logger.warn "#{klass.name}: overriding method '#{method_name}'!"
         end
       end

--- a/lib/aasm/configuration.rb
+++ b/lib/aasm/configuration.rb
@@ -41,6 +41,13 @@ module AASM
     # Configure a logger, with default being a Logger to STDERR
     attr_accessor :logger
 
+    # Hide warnings
+    attr_writer :hide_warnings
+
+    def hide_warnings
+      self.class.hide_warnings || @hide_warnings
+    end
+
     class << self
       attr_accessor :hide_warnings
     end

--- a/spec/unit/override_warning_spec.rb
+++ b/spec/unit/override_warning_spec.rb
@@ -91,4 +91,26 @@ describe 'warns when overrides a method' do
       end
     end
   end
+
+  context "when instance disables warnings" do
+    let(:base_klass) do
+      Class.new do
+        def save!; end
+      end
+    end
+
+    subject do
+      base_klass.instance_eval do
+        include AASM
+        aasm hide_warnings: true do
+          event(:save) { }
+        end
+      end
+    end
+
+    it "should not log to warn" do
+      expect_any_instance_of(Logger).to receive(:warn).never
+      subject
+    end
+  end
 end


### PR DESCRIPTION
In cases where warnings can be ignored it would be useful to be able to disable them, but still keep them enabled to notify developers of future problems.

This change allows the `hide_warnings` flag to be configured per-instance, disabling the warning emitting only for a single object.