### PR TITLE
docs: improve wording for overriding AASM state column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,7 @@ end
 ### Column name & migration
 
 As a default AASM uses the column `aasm_state` to store the states. You can override
-this by defining your favorite column name, using `:column` like this:
+this by defining a custom column name, using `:column` like this:
 
 ```ruby
 class Job < ActiveRecord::Base


### PR DESCRIPTION
The documentation previously used the phrase "defining your favorite column name,"  which sounded informal and imprecise. Updated the sentence to:

"As a default, AASM uses the column `aasm_state` to store the states. You can  override this by defining a custom column name, using `:column` like this:"

This change improves clarity and aligns the tone with standard technical  documentation practices.