### PR TITLE
Add keyword arguments support to ProcInvoker

### DIFF
--- a/lib/aasm/core/invokers/proc_invoker.rb
+++ b/lib/aasm/core/invokers/proc_invoker.rb
@@ -30,11 +30,40 @@ module AASM
           subject.respond_to?(:parameters)
         end
 
+        def keyword_arguments?
+          return false unless support_parameters?
+          subject.parameters.any? { |type, _| [:key, :keyreq].include?(type) }
+        end
+
+        def exec_proc_with_keyword_args(parameters_size)
+          positional_args, keyword_args = parse_arguments
+
+          if keyword_args.nil?
+            if parameters_size < 0
+              record.instance_exec(*positional_args, &subject)
+            else
+              record.instance_exec(*positional_args[0..(parameters_size - 1)], &subject)
+            end
+          else
+            if parameters_size < 0
+              record.instance_exec(*positional_args, **keyword_args, &subject)
+            else
+              record.instance_exec(*positional_args[0..(parameters_size - 1)], **keyword_args, &subject)
+            end
+          end
+        end
+
         # rubocop:disable Metrics/AbcSize
         def exec_proc(parameters_size)
-          return record.instance_exec(&subject) if parameters_size.zero?
-          return record.instance_exec(*args, &subject) if parameters_size < 0
-          record.instance_exec(*args[0..(parameters_size - 1)], &subject)
+          return record.instance_exec(&subject) if parameters_size.zero? && !keyword_arguments?
+          
+          if keyword_arguments?
+            exec_proc_with_keyword_args(parameters_size)
+          elsif parameters_size < 0
+            record.instance_exec(*args, &subject)
+          else
+            record.instance_exec(*args[0..(parameters_size - 1)], &subject)
+          end
         end
         # rubocop:enable Metrics/AbcSize
 
@@ -48,8 +77,14 @@ module AASM
 
         def parameters_to_arity
           subject.parameters.inject(0) do |memo, parameter|
-            memo += 1
-            memo *= -1 if parameter[0] == :rest && memo > 0
+            case parameter[0]
+            when :key, :keyreq
+              # Keyword arguments don't count towards positional arity
+            when :rest
+              memo = memo > 0 ? -memo : -1
+            else
+              memo += 1
+            end
             memo
           end
         end

--- a/spec/models/active_record/validator.rb
+++ b/spec/models/active_record/validator.rb
@@ -1,9 +1,11 @@
 class Validator < ActiveRecord::Base
   attr_accessor :after_all_transactions_performed,
     :after_transaction_performed_on_fail,
+    :after_transaction_performed_on_fail_with_reason,
     :after_transaction_performed_on_run,
     :before_all_transactions_performed,
     :before_transaction_performed_on_fail,
+    :before_transaction_performed_on_fail_with_reason,
     :before_transaction_performed_on_run,
     :invalid
 
@@ -47,6 +49,18 @@ class Validator < ActiveRecord::Base
 
       before_transaction do
         @before_transaction_performed_on_fail = true
+      end
+
+      transitions :to => :failed, :from => [:sleeping, :running]
+    end
+
+    event :fail_with_reason do
+      after_transaction do |reason:, **|
+        @after_transaction_performed_on_fail_with_reason = reason
+      end
+
+      before_transaction do |reason:, **|
+        @before_transaction_performed_on_fail_with_reason = reason
       end
 
       transitions :to => :failed, :from => [:sleeping, :running]

--- a/spec/unit/invokers/proc_invoker_spec.rb
+++ b/spec/unit/invokers/proc_invoker_spec.rb
@@ -82,5 +82,54 @@ describe AASM::Core::Invokers::ProcInvoker do
         expect { subject.invoke_subject }.not_to raise_error
       end
     end
+
+    context 'when passing keyword arguments' do
+      let(:args) { [1, key: 2] }
+      let(:target) { ->(_a, key: nil) {} }
+
+      it 'then correctly uses passed keyword arguments' do
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end
+
+    context 'when passing optional keyword arguments' do
+      let(:args) { [1, foo: 1] }
+      let(:target) { ->(_a, key: nil, foo:) {} }
+
+      it 'then correctly uses passed keyword arguments' do
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end
+
+    context 'when passing required keyword arguments like the failing test' do
+      let(:args) { [reason: 'test_reason'] }
+      let(:target) { proc { |reason:, **| @reason = reason } }
+
+      it 'should pass the keyword arguments correctly' do
+        subject.invoke_subject
+        expect(record.instance_variable_get(:@reason)).to eq('test_reason')
+      end
+    end
+
+    context 'when passing empty optional keyword arguments' do
+      let(:args) { [1] }
+      let(:target) { ->(_a, key: nil) {} }
+
+      it 'then correctly uses passed keyword arguments' do
+        expect { subject.invoke_subject }.not_to raise_error
+      end
+    end
+
+    context 'when using splat args like existing tests' do
+      let(:args) { ['blue', 'jeans'] }
+      
+      it 'should pass all arguments to splat parameter' do
+        received_args = []
+        target = proc { |*args| received_args.push(*args) }
+        invoker = described_class.new(target, record, args)
+        invoker.invoke_subject
+        expect(received_args).to eq(['blue', 'jeans'])
+      end
+    end
   end
 end

--- a/spec/unit/persistence/active_record_persistence_spec.rb
+++ b/spec/unit/persistence/active_record_persistence_spec.rb
@@ -708,6 +708,18 @@ if defined?(ActiveRecord)
               expect(validator).to_not be_running
             end
 
+            it "should fire :#{event_type}_transaction if transaction failed w/ kwarg" do
+              validator = Validator.create(:name => 'name')
+              expect do
+                begin
+                  validator.fail_with_reason!(reason: 'reason')
+                rescue => ignored
+                  expect(ignored).not_to be_instance_of(ArgumentError)
+                end
+              end.to change { validator.send("#{event_type}_transaction_performed_on_fail_with_reason") }.from(nil).to('reason')
+              expect(validator).to_not be_running
+            end
+
             it "should not fire :#{event_type}_transaction if not saving" do
               validator = Validator.create(:name => 'name')
               expect(validator).to be_sleeping


### PR DESCRIPTION
Fixes a regression we encountered upgrading from ruby 3.1 to 3.3

- Add keyword_arguments? method to detect procs with keyword parameters
- Implement exec_proc_with_keyword_args to handle keyword argument passing
- Update parameters_to_arity to correctly handle keyword and rest parameters
- Fix exec_proc to route to keyword handling when appropriate
- Add comprehensive test coverage for keyword argument scenarios
- Ensure backward compatibility with existing splat argument behavior