### PR TITLE
Avoid namespace naming collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![codecov](https://codecov.io/gh/aasm/aasm/branch/master/graph/badge.svg)](https://codecov.io/gh/aasm/aasm)
 
 ## Index
+- [Upgrade from version 5 to 6](#upgrade-from-version-5-to-6)
 - [Upgrade from version 3 to 4](#upgrade-from-version-3-to-4)
 - [Usage](#usage)
   - [Callbacks](#callbacks)
@@ -58,6 +59,10 @@ This package contains AASM, a library for adding finite state machines to Ruby c
 AASM started as the *acts_as_state_machine* plugin but has evolved into a more generic library
 that no longer targets only ActiveRecord models. It currently provides adapters for many
 ORMs but it can be used for any Ruby class, no matter what parent class it has (if any).
+
+## Upgrade from version 5 to 6
+
+Take a look at the [README_FROM_VERSION_5_TO_6](https://github.com/aasm/aasm/blob/master/README_FROM_VERSION_5_TO_6.md) for details how to switch from version 5.x to 6.0 of _AASM_.
 
 ## Upgrade from version 3 to 4
 
@@ -535,7 +540,9 @@ machine. If no namespace is provided, the latest definition "wins" and
 overrides previous definitions. Nonetheless, a warning is issued:
 `SimpleMultipleExample: overriding method 'run'!`.
 
-Alternatively, you can provide a namespace for each state machine:
+Alternatively, you can provide a namespace for each state machine. When a namespace
+is used, event methods are defined with the namespace as a suffix, preventing
+collisions between state machines that share event names:
 
 ```ruby
 class NamespacedMultipleExample

--- a/README_FROM_VERSION_5_TO_6.md
+++ b/README_FROM_VERSION_5_TO_6.md
@@ -1,0 +1,130 @@
+# Migrating from _AASM_ version 5 to 6
+
+## Must
+
+### Namespaced event methods no longer define plain-named methods
+
+When using `namespace:`, event methods are now defined directly with the namespace
+suffix. The plain-named methods are no longer created. This fixes a long-standing
+issue where two namespaced state machines with the same event name would collide,
+with the second definition silently overwriting the first.
+
+Before (v5):
+
+```ruby
+class Vehicle
+  include AASM
+
+  aasm(:car, namespace: :car) do
+    state :unsold, initial: true
+    state :sold
+
+    event :sell do
+      transitions from: :unsold, to: :sold
+    end
+  end
+end
+
+vehicle = Vehicle.new
+vehicle.sell!       # worked (plain method, defined first)
+vehicle.sell_car!   # worked (alias pointing to plain method)
+vehicle.may_sell?   # worked
+```
+
+After (v6):
+
+```ruby
+vehicle = Vehicle.new
+vehicle.sell!       # => NoMethodError — no longer defined
+vehicle.sell_car!   # works (directly defined)
+vehicle.may_sell?   # => NoMethodError — no longer defined
+vehicle.may_sell_car? # works
+```
+
+**Migration:** Replace all calls to plain event methods with their namespaced
+equivalents:
+
+- `sell!` → `sell_car!`
+- `sell` → `sell_car`
+- `may_sell?` → `may_sell_car?`
+- `sell_without_validation!` → `sell_car_without_validation!`
+
+The `aasm.fire(:event)` and `aasm.fire!(:event)` APIs continue to accept the
+plain event name and resolve to the correct namespaced method internally. No
+changes needed for code using this API:
+
+```ruby
+vehicle.aasm(:car).fire!(:sell)  # still works, resolves to sell_car! internally
+```
+
+### If you manually prefixed event names to work around collisions
+
+In v5, a common workaround for the collision problem was to manually include the
+namespace in the event name. In v6, this is no longer needed because the namespace
+is applied automatically. If you don't update your DSL, you'll end up with a
+double suffix:
+
+Before (v5 workaround):
+
+```ruby
+aasm(:review_status, namespace: :review) do
+  event :approve_review do  # manual prefix to avoid collision with another :approve
+    transitions from: :unapproved, to: :approved
+  end
+end
+
+obj.approve_review   # worked in v5
+obj.approve_review!  # worked in v5
+```
+
+After (v6, if you don't update):
+
+```ruby
+# The namespace "review" is now appended automatically, resulting in:
+obj.approve_review_review   # double suffix!
+obj.approve_review_review!  # double suffix!
+```
+
+**Migration:** Remove the manual namespace prefix from event names in the DSL:
+
+```ruby
+aasm(:review_status, namespace: :review) do
+  event :approve do  # just use the plain name
+    transitions from: :unapproved, to: :approved
+  end
+end
+
+obj.approve_review   # correct — namespace applied automatically
+obj.approve_review!  # correct
+```
+
+### `whiny_persistence` is now `true` by default
+
+Previously, `whiny_persistence` defaulted to `false`, meaning bang events (`run!`)
+would silently return `false` when the object failed persistence (e.g. ActiveRecord
+validation errors). Now it defaults to `true`, raising an exception instead.
+
+Before (v5):
+
+```ruby
+job.run!  # => false (if validation fails, no exception raised)
+```
+
+After (v6):
+
+```ruby
+job.run!  # => raises AASM::InvalidTransition (if validation fails)
+```
+
+**Migration:** If you relied on the silent `false` behavior, explicitly set
+`whiny_persistence: false`:
+
+```ruby
+class Job < ActiveRecord::Base
+  include AASM
+
+  aasm whiny_persistence: false do
+    ...
+  end
+end
+```

--- a/lib/aasm/base.rb
+++ b/lib/aasm/base.rb
@@ -114,31 +114,27 @@ module AASM
       aasm_name = @name.to_sym
       event = name.to_sym
 
+      # Compute method name with namespace (mirrors how states work on line 98)
+      method_name = namespace? ? "#{name}_#{namespace}" : name
+
       # an addition over standard aasm so that, before firing an event, you can ask
       # may_event? and get back a boolean that tells you whether the guard method
       # on the transition will let this happen.
-      safely_define_method klass, "may_#{name}?", ->(*args) do
+      safely_define_method klass, "may_#{method_name}?", ->(*args) do
         aasm(aasm_name).may_fire_event?(event, *args)
       end
 
-      safely_define_method klass, "#{name}!", ->(*args, &block) do
+      safely_define_method klass, "#{method_name}!", ->(*args, &block) do
         aasm(aasm_name).current_event = :"#{name}!"
         aasm_fire_event(aasm_name, event, {:persist => true}, *args, &block)
       end
 
-      safely_define_method klass, name, ->(*args, &block) do
+      safely_define_method klass, method_name, ->(*args, &block) do
         aasm(aasm_name).current_event = event
         aasm_fire_event(aasm_name, event, {:persist => false}, *args, &block)
       end
 
       skip_instance_level_validation(event, name, aasm_name, klass)
-
-      # Create aliases for the event methods. Keep the old names to maintain backwards compatibility.
-      if namespace?
-        klass.send(:alias_method, "may_#{name}_#{namespace}?", "may_#{name}?")
-        klass.send(:alias_method, "#{name}_#{namespace}!", "#{name}!")
-        klass.send(:alias_method, "#{name}_#{namespace}", name)
-      end
 
     end
 
@@ -264,7 +260,8 @@ module AASM
     def skip_instance_level_validation(event, name, aasm_name, klass)
       # Overrides the skip_validation config for an instance (If skip validation is set to false in original config) and
       # restores it back to the original value after the event is fired.
-      safely_define_method klass, "#{name}_without_validation!", ->(*args, &block) do
+      method_name = namespace? ? "#{name}_#{namespace}" : name
+      safely_define_method klass, "#{method_name}_without_validation!", ->(*args, &block) do
         original_config = AASM::StateMachineStore.fetch(self.class, true).machine(aasm_name).config.skip_validation_on_save
         begin
           AASM::StateMachineStore.fetch(self.class, true).machine(aasm_name).config.skip_validation_on_save = true unless original_config

--- a/lib/aasm/instance_base.rb
+++ b/lib/aasm/instance_base.rb
@@ -68,9 +68,9 @@ module AASM
         # filters the results of events_for_current_state so that only those that
         # are really currently possible (given transition guards) are shown.
         if options[:permitted]
-          events.select! { |e| @instance.send("may_#{e.name}?", *args) }
+          events.select! { |e| @instance.send("may_#{event_method_name(e.name)}?", *args) }
         else
-          events.select! { |e| !@instance.send("may_#{e.name}?", *args) }
+          events.select! { |e| !@instance.send("may_#{event_method_name(e.name)}?", *args) }
         end
       end
 
@@ -115,13 +115,12 @@ module AASM
 
     def fire(event_name, *args, &block)
       event_exists?(event_name)
-
-      @instance.send(event_name, *args, &block)
+      @instance.send(event_method_name(event_name), *args, &block)
     end
 
     def fire!(event_name, *args, &block)
       event_exists?(event_name, true)
-      bang_event_name = "#{event_name}!".to_sym
+      bang_event_name = "#{event_method_name(event_name)}!".to_sym
       @instance.send(bang_event_name, *args, &block)
     end
 
@@ -132,6 +131,16 @@ module AASM
     end
 
     private
+
+    def event_method_name(event_name)
+      config = @instance.class.aasm(@name).state_machine.config
+      if config.namespace
+        ns = (config.namespace == true) ? @name : config.namespace
+        "#{event_name}_#{ns}"
+      else
+        event_name.to_s
+      end
+    end
 
     def event_exists?(event_name, bang = false)
       event = @instance.class.aasm(@name).state_machine.events[event_name.to_sym]

--- a/spec/models/collision_namespaced_example.rb
+++ b/spec/models/collision_namespaced_example.rb
@@ -1,0 +1,29 @@
+class CollisionNamespacedExample
+  include AASM
+
+  aasm(:work, namespace: :work) do
+    state :idle, :initial => true
+    state :running
+
+    event :start do
+      transitions :from => :idle, :to => :running
+    end
+
+    event :stop do
+      transitions :from => :running, :to => :idle
+    end
+  end
+
+  aasm(:engine, namespace: :engine) do
+    state :idle, :initial => true
+    state :running
+
+    event :start do
+      transitions :from => :idle, :to => :running
+    end
+
+    event :stop do
+      transitions :from => :running, :to => :idle
+    end
+  end
+end

--- a/spec/models/namespaced_multiple_example.rb
+++ b/spec/models/namespaced_multiple_example.rb
@@ -17,11 +17,11 @@ class NamespacedMultipleExample
     state :unapproved, :initial => true
     state :approved
 
-    event :approve_review do
+    event :approve do
       transitions :from => :unapproved, :to => :approved
     end
 
-    event :unapprove_review do
+    event :unapprove do
       transitions :from => :approved, :to => :unapproved
     end
   end

--- a/spec/unit/collision_namespaced_example_spec.rb
+++ b/spec/unit/collision_namespaced_example_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe 'namespaced state machines with identical event names' do
+  let(:example) { CollisionNamespacedExample.new }
+
+  it 'starts both machines in their initial states' do
+    expect(example.aasm(:work).current_state).to eq(:idle)
+    expect(example.aasm(:engine).current_state).to eq(:idle)
+    expect(example).to be_work_idle
+    expect(example).to be_engine_idle
+  end
+
+  it 'defines namespaced event methods without collision' do
+    expect(example).to respond_to(:start_work)
+    expect(example).to respond_to(:start_work!)
+    expect(example).to respond_to(:may_start_work?)
+    expect(example).to respond_to(:stop_work)
+    expect(example).to respond_to(:stop_work!)
+    expect(example).to respond_to(:may_stop_work?)
+
+    expect(example).to respond_to(:start_engine)
+    expect(example).to respond_to(:start_engine!)
+    expect(example).to respond_to(:may_start_engine?)
+    expect(example).to respond_to(:stop_engine)
+    expect(example).to respond_to(:stop_engine!)
+    expect(example).to respond_to(:may_stop_engine?)
+  end
+
+  it 'does not define plain-named event methods' do
+    expect(example).not_to respond_to(:start)
+    expect(example).not_to respond_to(:start!)
+    expect(example).not_to respond_to(:may_start?)
+    expect(example).not_to respond_to(:stop)
+    expect(example).not_to respond_to(:stop!)
+    expect(example).not_to respond_to(:may_stop?)
+  end
+
+  it 'transitions each machine independently' do
+    expect(example).to be_work_idle
+    expect(example).to be_engine_idle
+
+    example.start_work!
+    expect(example).to be_work_running
+    expect(example).to be_engine_idle
+
+    example.start_engine!
+    expect(example).to be_work_running
+    expect(example).to be_engine_running
+
+    example.stop_work!
+    expect(example).to be_work_idle
+    expect(example).to be_engine_running
+  end
+
+  it 'reports correct may_fire? for each machine' do
+    expect(example.may_start_work?).to be true
+    expect(example.may_stop_work?).to be false
+    expect(example.may_start_engine?).to be true
+    expect(example.may_stop_engine?).to be false
+
+    example.start_work!
+    expect(example.may_start_work?).to be false
+    expect(example.may_stop_work?).to be true
+    expect(example.may_start_engine?).to be true
+    expect(example.may_stop_engine?).to be false
+  end
+
+  it 'supports fire/fire! via aasm instance with plain event names' do
+    example.aasm(:work).fire!(:start)
+    expect(example).to be_work_running
+    expect(example).to be_engine_idle
+
+    example.aasm(:engine).fire!(:start)
+    expect(example).to be_engine_running
+  end
+end

--- a/spec/unit/namespaced_multiple_example_spec.rb
+++ b/spec/unit/namespaced_multiple_example_spec.rb
@@ -60,6 +60,15 @@ describe 'state machine' do
     namespaced.return_car
   end
 
+  it 'does not define plain-named methods for namespaced events' do
+    expect(namespaced).not_to respond_to(:sell)
+    expect(namespaced).not_to respond_to(:sell!)
+    expect(namespaced).not_to respond_to(:may_sell?)
+    expect(namespaced).not_to respond_to(:return)
+    expect(namespaced).not_to respond_to(:return!)
+    expect(namespaced).not_to respond_to(:may_return?)
+  end
+
   it 'defines constants for each state name' do
     expect(NamespacedMultipleExample::STATE_UNAPPROVED).to eq(:unapproved)
     expect(NamespacedMultipleExample::STATE_APPROVED).to eq(:approved)
@@ -70,6 +79,4 @@ describe 'state machine' do
     expect(NamespacedMultipleExample::STATE_CAR_UNSOLD).to eq(:unsold)
     expect(NamespacedMultipleExample::STATE_CAR_SOLD).to eq(:sold)
   end
-
-
 end


### PR DESCRIPTION
Define namespaced event methods directly instead of aliasing (fixes #519). When using namespace, event methods (e.g. sell_car!, may_sell_car?) are now defined directly with the namespaced name rather than defining plain-named methods and aliasing them. This prevents method collisions when multiple namespaced state machines share the same event name.

This is a breaking change: plain-named event methods (sell!, may_sell?) are no longer defined when a namespace is active. Update all call sites to use the namespaced form.

Also adds v5-to-v6 migration guide (README_FROM_VERSION_5_TO_6.md).