### PR TITLE
Fix Minitest compatibility

### DIFF
--- a/gemfiles/norails.gemfile
+++ b/gemfiles/norails.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3", ">= 1.3.5", platforms: :ruby
 gem "rails", install_if: false
+gem "minitest", "~> 5.0"
 gem "after_commit_everywhere", install_if: false
 gem "sequel"
 gem "redis-objects", "1.6.0"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.4", platforms: :ruby
 gem "rails", "~> 6.0.6.1"
+gem "minitest", "~> 5.0"
 gem "after_commit_everywhere", "~> 1.0"
 gem "mongoid", "~>7.0", ">= 7.0.5"
 gem "sequel"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.4", platforms: :ruby
 gem "rails", "~> 7.0.1"
+gem "minitest", "~> 5.0"
 gem "after_commit_everywhere", "~> 1.0"
 gem "mongoid", "~>7.0", ">= 7.0.5"
 gem "sequel"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.4", platforms: :ruby
 gem "rails", "~> 7.1.0"
+gem "minitest", "~> 5.0"
 gem "after_commit_everywhere"
 gem "redis-objects"
 gem "mongoid"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "sqlite3", platforms: :ruby
 gem "rails", "~> 7.2.0"
+gem "minitest", "~> 5.0"
 gem "after_commit_everywhere", "~> 1.0"
 gem "mongoid", github: "mongodb/mongoid"
 gem "sequel"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "sqlite3", platforms: :ruby
 gem "rails", "~> 8.0.0"
+gem "minitest", "~> 5.0"
 gem "after_commit_everywhere", "~> 1.0"
 gem "mongoid", github: "mongodb/mongoid"
 gem "sequel"


### PR DESCRIPTION
Use Minitest v5 for now and see if this fixes the minitest-matcher issues.