### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,8 +764,8 @@ job.aasm.fire!(:run) # saved
 ```
 
 Saving includes running all validations on the `Job` class. If
-`whiny_persistence` flag is set to `true`, exception is raised in case of
-failure. If `whiny_persistence` flag is set to `false`, methods with a bang return
+`whiny_transitions` flag is set to `true`, exception is raised in case of
+failure. If `whiny_transitions` flag is set to `false`, methods with a bang return
 `true` if the state transition is successful or `false` if an error occurs.
 
 If you want make sure the state gets saved without running validations (and


### PR DESCRIPTION
Currently, in the README the `whiny_transitions` flag is incorrectly documented as `whiny_persistence` in one section. This is a mistake and should be fixed to remove any confusion.

This change addresses the need by:
* Updating the README, changing `whiny_persistence` to `whiny_transitions`